### PR TITLE
Stop the sdk test build task from preventing pushes to remote.

### DIFF
--- a/.github/workflows/ci-dev-sdk.yml
+++ b/.github/workflows/ci-dev-sdk.yml
@@ -96,7 +96,7 @@ jobs:
         run: docker logs api --tail all
 
       - name: Run SDK tests
-        run: cd packages/sdk/ && yarn test
+        run: cd packages/sdk/ && yarn int-test
         env:
           ADMIN_PRIVATE_KEY_SDK: ${{ secrets.SDK_DEFAULT_ANVIL_KEY }}
           ADMIN_EMAIL_SDK: admin@cbl.com

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - Ìf you only want to work on the contracts, you don't need to setup the whole project. Please go directly to [`contracts/`](./packages/contracts/README.md) and follow the instructions there.
 ---
 - Ensure that you have:
-    - NodeJS + Yarn ([install yarn](https://yarnpkg.com/getting-started/install))
+    - NodeJS + Yarn ([install yarn](https://v3.yarnpkg.com/getting-started/install))
     - Foundry ([install forge](https://book.getfoundry.sh/getting-started/installation))
     - Docker ([install docker](https://docs.docker.com/get-docker/))
     - Supabase CLI ([install the cli](https://github.com/supabase/cli#install-the-cli)) Hint: choose a native client for

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,11 +1,13 @@
 # api
 
 ## Run
+
 ```bash
 yarn dev
 ```
 
 ## Supabase Stop/Start
+
 ```bash
 # start and initialize database
 supabase start
@@ -21,12 +23,10 @@ supabase stop
 supabase stop --no-backup
 ```
 
-## API 
+## API
 
 ### API Docs : http://localhost:3001/api/docs
 
 1. To execute a script, create a User (via App or Script)
 1. Authenticate using Swagger http://localhost:3001/api/docs#/Authentication
 1. Click "Authorize" button and provide the bearer token from step #2
-
-

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,1 +1,3 @@
-# sdk
+# SDK
+
+Add details and link from root README.md

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -10,7 +10,7 @@ import { SiweMessage, generateNonce } from 'siwe';
 import { decodeContractError } from './src/utils/utils';
 
 export class CredbullSDK {
-  private SERVICE_URL = process.env.API_BASE_URL || "";
+  private SERVICE_URL = process.env.API_BASE_URL || '';
   constructor(
     private access_token: string,
     private signer: Signer,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -8,7 +8,7 @@
     "deposit": "ts-node mock/deposit.ts",
     "format": "prettier . --write",
     "build": "tsc",
-    "test": "playwright test",
+    "int-test": "playwright test",
     "report": "playwright show-report"
   },
   "dependencies": {

--- a/packages/sdk/tests/utils/admin-ops.ts
+++ b/packages/sdk/tests/utils/admin-ops.ts
@@ -141,7 +141,10 @@ export async function toggleWindowCheck(
 }
 
 export async function getAdminSigner() {
-  return new Wallet(process.env.ADMIN_PRIVATE_KEY_SDK || '', new providers.JsonRpcProvider(`${process.env.RPC_PROVIDER}`));
+  return new Wallet(
+    process.env.ADMIN_PRIVATE_KEY_SDK || '',
+    new providers.JsonRpcProvider(`${process.env.RPC_PROVIDER}`),
+  );
 }
 
 export async function sleep(ms: number) {


### PR DESCRIPTION
This is to stop running `sdk` `test` on `git push` which requires a server to be running and a clean environment.
So basically, sdk testing is blocking (or over-complicating) the developer workflow. This is the initial attempt
by a noob to fix this issue.