### PR TITLE
Standardise Ethereum TOML configuration keys

### DIFF
--- a/packages/api/resource/api-local.toml
+++ b/packages/api/resource/api-local.toml
@@ -1,22 +1,23 @@
 ##
-# The Application Configuration for the Local Environment (local development). 
+# The Application Configuration for the Local Environment (local development).
 ##
 
-node_env="development"
+node_env = "development"
 
 [api]
-port=3001
-version="0.0.1"
+port = 3001
+version = "0.0.1"
 
 [services.sync_vaults]
-block_history=1000
+block_history = 1000
 
 [services.supabase]
 url = "http://127.0.0.1:54321"
 
 [services.ethers]
-url="http://127.0.0.1:8545"
-wss="wss://127.0.0.1:8545"
+url = "http://127.0.0.1:8545"
+wss = "ws://127.0.0.1:8545"
 
+[evm.address]
 # Dev/Anvil Wallet, Account[1]
-operator.public_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+operator = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"

--- a/packages/api/resource/api-testnet.toml
+++ b/packages/api/resource/api-testnet.toml
@@ -2,23 +2,24 @@
 # The Application Configuration for the TestNet Environment.
 ##
 
-node_env="testnet"
+node_env = "testnet"
 
 [api]
 #TODO - confirm port
-port=3001
-version="0.0.1"
+port = 3001
+version = "0.0.1"
 
 [services.sync_vaults]
-block_history=1000
+block_history = 1000
 
 [services.supabase]
 url = "https://kyvvhlnmoqibdihqrlmc.supabase.co"
 
 [services.ethers]
 # settings for baseSepolia, see others: https://chainlist.org/
-url="https://sepolia.base.org"
-wss="https://sepolia.base.org"
+url = "https://sepolia.base.org"
+wss = "https://sepolia.base.org"
 
+[evm.address]
 # devops operator (wallet 2) - public address, okay to share
-operator.public_address = "0xaD3C004eE1f942BFDA2DA0D2DAaC94d6aC012F75"
+operator = "0xaD3C004eE1f942BFDA2DA0D2DAaC94d6aC012F75"

--- a/packages/api/src/modules/notification/notifications.service.ts
+++ b/packages/api/src/modules/notification/notifications.service.ts
@@ -16,7 +16,7 @@ export class NotificationsService implements OnModuleInit {
     private readonly ethers: EthersService,
     private readonly tomlConfigService: TomlConfigService,
   ) {
-    this.operator = tomlConfigService.config.services.ethers.operator.public_key;
+    this.operator = tomlConfigService.config.evm.address.operator;
     this.slack = new WebClient(tomlConfigService.config.secret.SLACK_TOKEN?.value);
   }
 

--- a/packages/contracts/resource/dev.toml
+++ b/packages/contracts/resource/dev.toml
@@ -9,12 +9,10 @@ chain_id = 84532
 
 [evm.address]
 # credbull-devops wallets.  wallet numbers are 1-based (as opposed to 0-based in anvil)
-# devops deployer (wallet 5)
-deployer.private_key = ""
 # devops admin/owner (wallet 1)
-owner.public_address = "0xD79Be36f61fce3B8EF2FBF22b13B2b9a68eE15A2"
+owner = "0xD79Be36f61fce3B8EF2FBF22b13B2b9a68eE15A2"
 # devops operator (wallet 2)
-operator.public_address = "0xaD3C004eE1f942BFDA2DA0D2DAaC94d6aC012F75"
+operator = "0xaD3C004eE1f942BFDA2DA0D2DAaC94d6aC012F75"
 
 [evm.contracts.upside_vault]
 # 2 decimal place percentage (meaining value divided by 100) as integer.

--- a/packages/contracts/resource/dev.toml
+++ b/packages/contracts/resource/dev.toml
@@ -7,7 +7,7 @@
 # blockchain id, e.g. baseSepolia=84532, arbSepolia=421614
 chain_id = 84532
 
-[evm.contracts]
+[evm.address]
 # credbull-devops wallets.  wallet numbers are 1-based (as opposed to 0-based in anvil)
 # devops deployer (wallet 5)
 deployer.private_key = ""
@@ -21,7 +21,6 @@ operator.public_address = "0xaD3C004eE1f942BFDA2DA0D2DAaC94d6aC012F75"
 collateral_percentage = 200
 
 [services.supabase]
-
 url = "https://kyvvhlnmoqibdihqrlmc.supabase.co"
 
 # Export contract details to supabase.

--- a/packages/contracts/resource/local.toml
+++ b/packages/contracts/resource/local.toml
@@ -8,16 +8,15 @@ chain_id = 31337
 
 [evm.address]
 # Dev/Anvil Wallet, Account[0]
-owner.public_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+owner = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 # Dev/Anvil Wallet, Account[1]
-operator.public_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+operator = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 
 [evm.contracts.upside_vault]
 # 2 decimal place percentage (meaining value divided by 100) as integer.
 collateral_percentage = 20_00
 
 [services.supabase]
-# Local Anvil URL.
 url = "http://127.0.0.1:54321"
 
 # Export contract details to supabase.

--- a/packages/contracts/resource/local.toml
+++ b/packages/contracts/resource/local.toml
@@ -1,12 +1,12 @@
 ##
-# The Application Configuration for the Local Environment (local development). 
+# The Application Configuration for the Local Environment (local development).
 ##
 
 [evm]
 # blockchain id
 chain_id = 31337
 
-[evm.contracts]
+[evm.address]
 # Dev/Anvil Wallet, Account[0]
 owner.public_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 # Dev/Anvil Wallet, Account[1]

--- a/packages/contracts/resource/testnet.toml
+++ b/packages/contracts/resource/testnet.toml
@@ -1,12 +1,12 @@
 ##
-# The Application Configuration for the TestNet Environment. 
+# The Application Configuration for the TestNet Environment.
 ##
 
 [evm]
 # blockchain id, e.g. baseSepolia=84532, arbSepolia=421614
 chain_id = 84532
 
-[evm.contracts]
+[evm.address]
 # credbull-devops wallets.  wallet numbers are 1-based (as opposed to 0-based in anvil)
 # devops admin/owner (wallet 1) - public address, okay to share
 owner.public_address = "0xD79Be36f61fce3B8EF2FBF22b13B2b9a68eE15A2"

--- a/packages/contracts/resource/testnet.toml
+++ b/packages/contracts/resource/testnet.toml
@@ -9,16 +9,15 @@ chain_id = 84532
 [evm.address]
 # credbull-devops wallets.  wallet numbers are 1-based (as opposed to 0-based in anvil)
 # devops admin/owner (wallet 1) - public address, okay to share
-owner.public_address = "0xD79Be36f61fce3B8EF2FBF22b13B2b9a68eE15A2"
+owner = "0xD79Be36f61fce3B8EF2FBF22b13B2b9a68eE15A2"
 # devops operator (wallet 2) - public address, okay to share
-operator.public_address = "0xaD3C004eE1f942BFDA2DA0D2DAaC94d6aC012F75"
+operator = "0xaD3C004eE1f942BFDA2DA0D2DAaC94d6aC012F75"
 
 [evm.contracts.upside_vault]
 # 2 decimal place percentage (meaining value divided by 100) as integer.
 collateral_percentage = 200
 
 [services.supabase]
-
 url = "https://kyvvhlnmoqibdihqrlmc.supabase.co"
 
 # Export contract details to supabase.

--- a/packages/contracts/script/HelperConfig.s.sol
+++ b/packages/contracts/script/HelperConfig.s.sol
@@ -85,8 +85,8 @@ contract HelperConfig is Script {
     /// @return The active Factory Parameters
     function createFactoryParamsFromConfig() internal view returns (FactoryParams memory) {
         FactoryParams memory factoryParams = FactoryParams({
-            owner: tomlConfig.readAddress(".evm.address.owner.public_address"),
-            operator: tomlConfig.readAddress(".evm.address.operator.public_address"),
+            owner: tomlConfig.readAddress(".evm.address.owner"),
+            operator: tomlConfig.readAddress(".evm.address.operator"),
             collateralPercentage: tomlConfig.readUint(".evm.contracts.upside_vault.collateral_percentage")
         });
 

--- a/packages/contracts/script/HelperConfig.s.sol
+++ b/packages/contracts/script/HelperConfig.s.sol
@@ -85,8 +85,8 @@ contract HelperConfig is Script {
     /// @return The active Factory Parameters
     function createFactoryParamsFromConfig() internal view returns (FactoryParams memory) {
         FactoryParams memory factoryParams = FactoryParams({
-            owner: tomlConfig.readAddress(".evm.contracts.owner.public_address"),
-            operator: tomlConfig.readAddress(".evm.contracts.operator.public_address"),
+            owner: tomlConfig.readAddress(".evm.address.owner.public_address"),
+            operator: tomlConfig.readAddress(".evm.address.operator.public_address"),
             collateralPercentage: tomlConfig.readUint(".evm.contracts.upside_vault.collateral_percentage")
         });
 


### PR DESCRIPTION
* Change the `[evm.contracts]` key to instead be `[evm.address]`, as that is the data in the section.
* Updated all usages of said keys in `contracts` and `api`.
