### PR TITLE
Rename the `export_contracts` item to be clearer and more accurate.

### DIFF
--- a/packages/contracts/resource/ci.toml
+++ b/packages/contracts/resource/ci.toml
@@ -32,5 +32,5 @@ max_supply = 10_000_000 # 10 million in wei
 [services.supabase]
 url = "https://iucsqvvjujqcncowypnr.supabase.co"
 
-# Export contract details to supabase.
-export_contracts = true
+# Save the contract deployment details to the database.
+update_contract_addresses = true

--- a/packages/contracts/resource/local.toml
+++ b/packages/contracts/resource/local.toml
@@ -32,4 +32,4 @@ max_supply = 10_000_000 # 10 million in wei
 url = "http://127.0.0.1:54321"
 
 # Save the contract deployment details to the database.
-update_contracts_addresses = true
+update_contract_addresses = true

--- a/packages/contracts/resource/local.toml
+++ b/packages/contracts/resource/local.toml
@@ -31,5 +31,5 @@ max_supply = 10_000_000 # 10 million in wei
 [services.supabase]
 url = "http://127.0.0.1:54321"
 
-# Export contract details to supabase.
-export_contracts = true
+# Save the contract deployment details to the database.
+update_contracts_addresses = true

--- a/packages/contracts/resource/testnet.toml
+++ b/packages/contracts/resource/testnet.toml
@@ -32,5 +32,5 @@ max_supply = 10_000_000 # 10 million in wei
 [services.supabase]
 url = "https://kyvvhlnmoqibdihqrlmc.supabase.co"
 
-# Export contract details to supabase.
-export_contracts = true
+# Save the contract deployment details to the database.
+update_contract_addresses = true

--- a/packages/contracts/script/utils/exporter.js
+++ b/packages/contracts/script/utils/exporter.js
@@ -56,7 +56,7 @@ async function exportAddress(config) {
         dataToStoreOnDB.push(data);
       }
     }
-    if (config.services.supabase.export_contracts === true) {
+    if (config.services.supabase.update_contract_addresses === true) {
       await exportToSupabase(client, dataToStoreOnDB);
     }
   }


### PR DESCRIPTION
- [x] Rename `export_contracts` to `update_contract_addresses`.
Seeing as the item is in `services.supabase` the database-nature is clear, so using the a descriptive name is good.

Resolves https://github.com/credbull/credbull-defi/issues/77