### PR TITLE
Update `LiquidContinuousMultiTokenVault` to realise `ITripleRateContext`.

### DIFF
--- a/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
+++ b/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
@@ -54,7 +54,6 @@ contract LiquidContinuousMultiTokenVault is
 
     IYieldStrategy public immutable YIELD_STRATEGY; // TODO lucasia - confirm if immutable or not
 
-    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
 
     error LiquidContinuousMultiTokenVault__InvalidFrequency(uint256 frequency);
@@ -79,7 +78,6 @@ contract LiquidContinuousMultiTokenVault is
         }
 
         _grantRole(DEFAULT_ADMIN_ROLE, params.contractOwner);
-        _grantRole(PAUSER_ROLE, params.contractOwner);
         _grantRole(OPERATOR_ROLE, params.contractOwner);
 
         YIELD_STRATEGY = params.yieldStrategy;

--- a/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
+++ b/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
@@ -33,8 +33,8 @@ contract LiquidContinuousMultiTokenVault is
     MultiTokenVault,
     ITradeable,
     TimelockAsyncUnlock,
-    TripleRateContext,
     Timer,
+    TripleRateContext,
     ERC1155Pausable,
     AccessControl
 {
@@ -54,26 +54,33 @@ contract LiquidContinuousMultiTokenVault is
 
     IYieldStrategy public immutable YIELD_STRATEGY; // TODO lucasia - confirm if immutable or not
 
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+
     error LiquidContinuousMultiTokenVault__InvalidFrequency(uint256 frequency);
     error LiquidContinuousMultiTokenVault__InvalidOwnerAddress(address ownerAddress);
 
     constructor(VaultParams memory params)
         MultiTokenVault(params.asset)
         TimelockAsyncUnlock(params.redeemNoticePeriod)
-        TripleRateContext(
-            params.fullRateScaled,
-            params.reducedRateScaled,
-            params.frequency,
-            params.tenor,
-            params.asset.decimals()
-        )
         Timer(params.vaultStartTimestamp)
+        TripleRateContext(
+            ContextParams({
+                fullRateScaled: params.fullRateScaled,
+                initialReducedRate: PeriodRate({ interestRate: params.reducedRateScaled, effectiveFromPeriod: currentPeriod() }),
+                frequency: params.frequency,
+                tenor: params.tenor,
+                decimals: params.asset.decimals()
+            })
+        )
     {
         if (params.contractOwner == address(0)) {
             revert LiquidContinuousMultiTokenVault__InvalidOwnerAddress(params.contractOwner);
         }
 
         _grantRole(DEFAULT_ADMIN_ROLE, params.contractOwner);
+        _grantRole(PAUSER_ROLE, params.contractOwner);
+        _grantRole(OPERATOR_ROLE, params.contractOwner);
 
         YIELD_STRATEGY = params.yieldStrategy;
 
@@ -287,5 +294,28 @@ contract LiquidContinuousMultiTokenVault is
         returns (bool)
     {
         return MultiTokenVault.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @inheritdoc TripleRateContext
+     */
+    function setReducedRate(uint256 reducedRateScaled_, uint256 effectiveFromPeriod_)
+        public
+        override
+        onlyRole(OPERATOR_ROLE)
+    {
+        super.setReducedRate(effectiveFromPeriod_, reducedRateScaled_);
+    }
+
+    /**
+     * @notice Sets the `reducedRateScaled_` against the Current Period.
+     * @dev Convenience method for setting the Reduced Rate agains the current Period.
+     *  Reverts with [TripleRateContext_PeriodRegressionNotAllowed] if current Period is before the
+     *  stored current Period (the setting).  Emits [CurrentPeriodRateChanged] upon mutation.
+     *
+     * @param reducedRateScaled_ The scaled percentage 'reduced' Interest Rate.
+     */
+    function setReducedRateAtCurrent(uint256 reducedRateScaled_) public onlyRole(OPERATOR_ROLE) {
+        super.setReducedRate(currentPeriod(), reducedRateScaled_);
     }
 }

--- a/packages/contracts/src/yield/context/ITripleRateContext.sol
+++ b/packages/contracts/src/yield/context/ITripleRateContext.sol
@@ -4,34 +4,37 @@ pragma solidity ^0.8.20;
 import { ICalcInterestMetadata } from "@credbull/yield/ICalcInterestMetadata.sol";
 
 /**
- * @title A triple rate context, with the 'full' rate and 2 reduced rates that apply temporally across 2 tenor periods.
- * @dev Context for yield calculations with a rate and dual reduced rates, applicable across Tenor Periods. All rate
- *  are expressed in percentage terms and scaled using [scale()]. The 'full' rate values are encapsulated by the
- *  [ICalcInterestMetadata].
+ * @title A triple rate context, with the 'full' interest rate and 2 reduced interest rates that apply temporally
+ *  across 2 tenor periods.
+ * @dev Context for yield calculations with an interest rate and dual reduced interest rates, applicable across Tenor
+ *  Periods. All rate are expressed in percentage terms and scaled using [scale()]. The 'full' rate values are
+ *  encapsulated by the [ICalcInterestMetadata].
  */
 interface ITripleRateContext is ICalcInterestMetadata {
+    /// @notice Associates an Interest Rate with the Period from which it applies.
+    struct PeriodRate {
+        /// @dev The Interest Rate in percentage terms and scaled.
+        uint256 interestRate;
+        /// @dev The Period from which the associated rate applies.
+        uint256 effectiveFromPeriod;
+    }
+
     /// @notice Returns the number of periods required to earn the full rate.
     function numPeriodsForFullRate() external view returns (uint256 numPeriods);
 
     /**
-     * @notice Returns a tuple of the current Tenor Period and its associated Reduced Rate.
+     * @notice Returns the [PeriodRate] of the current (at invocation) Reduced Interest Rate and its
+     *  associated Period.
      *
-     * @return currentTenorPeriod The current Tenor Period.
-     * @return reducedRateInPercentageScaled The associated Reduced Rate.
+     * @return currentPeriodRate_ The current [PeriodRate].
      */
-    function currentTenorPeriodAndRate()
-        external
-        view
-        returns (uint256 currentTenorPeriod, uint256 reducedRateInPercentageScaled);
+    function currentPeriodRate() external view returns (PeriodRate memory currentPeriodRate_);
 
     /**
-     * @notice Returns a tuple of the previous Tenor Period and its associated Reduced Rate.
+     * @notice Returns the [PeriodRate] of the previous Reduced Interest Rate and its associated Period.
+     * @dev When the current [PeriodRate] is set, its existing value becomes the previous [PeriodRate].
      *
-     * @return previousTenorPeriod The previous Tenor Period.
-     * @return reducedRateInPercentageScaled The associated Reduced Rate.
+     * @return previousPeriodRate_ The previous [PeriodRate].
      */
-    function previousTenorPeriodAndRate()
-        external
-        view
-        returns (uint256 previousTenorPeriod, uint256 reducedRateInPercentageScaled);
+    function previousPeriodRate() external view returns (PeriodRate memory previousPeriodRate_);
 }

--- a/packages/contracts/src/yield/strategy/TripleRateYieldStrategy.sol
+++ b/packages/contracts/src/yield/strategy/TripleRateYieldStrategy.sol
@@ -7,7 +7,7 @@ import { IYieldStrategy } from "@credbull/yield/strategy/IYieldStrategy.sol";
 
 /**
  * @title TripleRateYieldStrategy
- * @dev Calculates returns using 1 'full' rate and 2 reduced rates, applied according to the Tenor Period, and
+ * @dev Calculates returns using 1 'full' rate and 2 'reduced' rates, applied according to the Tenor Period, and
  *  depending on the holding period.
  */
 contract TripleRateYieldStrategy is IYieldStrategy {
@@ -38,16 +38,16 @@ contract TripleRateYieldStrategy is IYieldStrategy {
         // Calculate interest for reduced-rate periods
         if (_noOfPeriods(fromPeriod, toPeriod) - noOfFullRatePeriods > 0) {
             uint256 firstReducedRatePeriod = _firstReducedRatePeriod(noOfFullRatePeriods, fromPeriod);
-            (uint256 currentTenorPeriod, uint256 currentReducedRate) = context.currentTenorPeriodAndRate();
+            ITripleRateContext.PeriodRate memory currentPeriodRate = context.currentPeriodRate();
 
             // Previous Tenor Period ... Current Tenor Period ... 1st Reduced Rate Period ... To Period
             // If the 1st RR Period is on or after the current Tenor Period, then RR Interest is:
             //  1st RR Period -> To Period @ Current Rate.
-            if (firstReducedRatePeriod >= currentTenorPeriod) {
+            if (firstReducedRatePeriod >= currentPeriodRate.effectiveFromPeriod) {
                 //  1st RR Period -> To Period @ Current Rate.
                 yield += CalcSimpleInterest.calcInterest(
                     principal,
-                    currentReducedRate,
+                    currentPeriodRate.interestRate,
                     toPeriod - firstReducedRatePeriod,
                     context.frequency(),
                     context.scale()
@@ -58,20 +58,24 @@ contract TripleRateYieldStrategy is IYieldStrategy {
             //  1st RR Period -> Current Period @ Previous Rate +
             //  Current Period -> To Period @ Current Rate.
             else {
-                ( /*uint256 previousTenorPeriod*/ , uint256 previousReducedRate) = context.previousTenorPeriodAndRate();
+                ITripleRateContext.PeriodRate memory previousPeriodRate = context.previousPeriodRate();
 
                 //  1st RR Period -> Current Period @ Previous Rate +
                 yield += CalcSimpleInterest.calcInterest(
                     principal,
-                    previousReducedRate,
-                    currentTenorPeriod - firstReducedRatePeriod,
+                    previousPeriodRate.interestRate,
+                    currentPeriodRate.effectiveFromPeriod - firstReducedRatePeriod,
                     context.frequency(),
                     context.scale()
                 );
 
                 //  Current Period -> To Period @ Current Rate.
                 yield += CalcSimpleInterest.calcInterest(
-                    principal, currentReducedRate, toPeriod - currentTenorPeriod, context.frequency(), context.scale()
+                    principal,
+                    currentPeriodRate.interestRate,
+                    toPeriod - currentPeriodRate.effectiveFromPeriod,
+                    context.frequency(),
+                    context.scale()
                 );
             }
         }

--- a/packages/contracts/test/src/yield/context/TripleRateContextTest.t.sol
+++ b/packages/contracts/test/src/yield/context/TripleRateContextTest.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import { ITripleRateContext } from "@credbull/yield/context/ITripleRateContext.sol";
 import { TripleRateContext } from "@credbull/yield/context/TripleRateContext.sol";
 import { TestTripleRateContext } from "@test/test/yield/context/TestTripleRateContext.t.sol";
 
@@ -17,6 +18,7 @@ contract TripleRateContextTest is Test {
     uint256 public constant PERCENT_5_5_SCALED = 55 * SCALE / 10; // 5.5%
     uint256 public constant PERCENT_10_SCALED = 10 * SCALE; // 10%
 
+    uint256 public constant EFFECTIVE_FROM_PERIOD = 0;
     uint256 public constant TENOR = 30;
 
     uint256 public immutable FREQUENCY = Frequencies.toValue(Frequencies.Frequency.DAYS_365);
@@ -24,50 +26,52 @@ contract TripleRateContextTest is Test {
     TripleRateContext internal toTest;
 
     function setUp() public {
-        toTest = new TestTripleRateContext(PERCENT_5_SCALED, PERCENT_5_5_SCALED, FREQUENCY, TENOR, DECIMALS);
+        toTest = new TestTripleRateContext(
+            PERCENT_5_SCALED, PERCENT_5_5_SCALED, EFFECTIVE_FROM_PERIOD, FREQUENCY, TENOR, DECIMALS
+        );
     }
 
     function test_TripleRateContext_ConstructedAsExpected() public view {
         assertEq(PERCENT_5_SCALED, toTest.rateScaled(), "Incorrect Full Rate");
         assertEq(TENOR, toTest.numPeriodsForFullRate(), "Incorrect No Of Period For Full Rate");
 
-        (uint256 currentTenorPeriod, uint256 currentReducedRate) = toTest.currentTenorPeriodAndRate();
-        assertEq(1, currentTenorPeriod, "Incorrect Current Tenor Period");
-        assertEq(PERCENT_5_5_SCALED, currentReducedRate, "Incorrect Current Reduced Rate");
+        ITripleRateContext.PeriodRate memory currentPeriodRate = toTest.currentPeriodRate();
+        assertEq(EFFECTIVE_FROM_PERIOD, currentPeriodRate.effectiveFromPeriod, "Incorrect Current Period");
+        assertEq(PERCENT_5_5_SCALED, currentPeriodRate.interestRate, "Incorrect Current Reduced Rate");
 
-        (uint256 previousTenorPeriod, uint256 previousReducedRate) = toTest.previousTenorPeriodAndRate();
-        assertEq(0, previousTenorPeriod, "Incorrect Previous Tenor Period");
-        assertEq(0, previousReducedRate, "Incorrect Previous Reduced Rate");
+        ITripleRateContext.PeriodRate memory previousPeriodRate = toTest.previousPeriodRate();
+        assertEq(0, previousPeriodRate.effectiveFromPeriod, "Incorrect Previous Period");
+        assertEq(0, previousPeriodRate.interestRate, "Incorrect Previous Reduced Rate");
     }
 
-    function test_TripleRateContext_SetCurrentTenorPeriodRateWorks() public {
+    function test_TripleRateContext_SetCurrentPeriodRateWorks() public {
         // Checked event emission.
         vm.expectEmit();
-        emit TripleRateContext.CurrentTenorPeriodAndRateChanged(3, PERCENT_10_SCALED);
+        emit TripleRateContext.CurrentPeriodRateChanged(PERCENT_10_SCALED, 3);
 
-        toTest.setReducedRateAt(3, PERCENT_10_SCALED);
+        toTest.setReducedRate(PERCENT_10_SCALED, 3);
 
-        (uint256 currentTenorPeriod, uint256 currentReducedRate) = toTest.currentTenorPeriodAndRate();
-        assertEq(3, currentTenorPeriod, "Incorrect Current Tenor Period");
-        assertEq(PERCENT_10_SCALED, currentReducedRate, "Incorrect Current Reduced Rate");
+        ITripleRateContext.PeriodRate memory currentPeriodRate = toTest.currentPeriodRate();
+        assertEq(3, currentPeriodRate.effectiveFromPeriod, "Incorrect Current Period");
+        assertEq(PERCENT_10_SCALED, currentPeriodRate.interestRate, "Incorrect Current Reduced Rate");
 
-        (uint256 previousTenorPeriod, uint256 previousReducedRate) = toTest.previousTenorPeriodAndRate();
-        assertEq(1, previousTenorPeriod, "Incorrect Previous Tenor Period");
-        assertEq(PERCENT_5_5_SCALED, previousReducedRate, "Incorrect Previous Reduced Rate");
+        ITripleRateContext.PeriodRate memory previousPeriodRate = toTest.previousPeriodRate();
+        assertEq(EFFECTIVE_FROM_PERIOD, previousPeriodRate.effectiveFromPeriod, "Incorrect Previous Period");
+        assertEq(PERCENT_5_5_SCALED, previousPeriodRate.interestRate, "Incorrect Previous Reduced Rate");
     }
 
-    function test_TripleRateContext_RevertSetCurrentTenorPeriodRate_WhenPeriodIsAtOrBeforeCurrent() public {
+    function test_TripleRateContext_RevertSetCurrentPeriodRate_WhenPeriodIsAtOrBeforeCurrent() public {
         // Before
         vm.expectRevert(
-            abi.encodeWithSelector(TripleRateContext.TripleRateContext_TenorPeriodRegressionNotAllowed.selector, 1, 0)
+            abi.encodeWithSelector(TripleRateContext.TripleRateContext_PeriodRegressionNotAllowed.selector, 0, 0)
         );
-        toTest.setReducedRateAt(0, PERCENT_10_SCALED);
+        toTest.setReducedRate(PERCENT_10_SCALED, 0);
 
-        toTest.setReducedRateAt(3, PERCENT_10_SCALED);
+        toTest.setReducedRate(PERCENT_10_SCALED, 3);
         // At
         vm.expectRevert(
-            abi.encodeWithSelector(TripleRateContext.TripleRateContext_TenorPeriodRegressionNotAllowed.selector, 3, 3)
+            abi.encodeWithSelector(TripleRateContext.TripleRateContext_PeriodRegressionNotAllowed.selector, 3, 3)
         );
-        toTest.setReducedRateAt(3, PERCENT_5_SCALED);
+        toTest.setReducedRate(PERCENT_5_SCALED, 3);
     }
 }

--- a/packages/contracts/test/src/yield/strategy/MultipleRateYieldStrategyScenarioTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/MultipleRateYieldStrategyScenarioTest.t.sol
@@ -34,7 +34,7 @@ contract MultipleRateYieldStrategyScenarioTest is YieldStrategyScenarioTest {
         return address(context);
     }
 
-    function _setReducedRateAt(uint256 _period, uint256 _reducedRate) internal virtual override {
-        context.setReducedRate(_period, _reducedRate);
+    function _setReducedRate(uint256 reducedRateScaled_, uint256 effectiveFromPeriod_) internal virtual override {
+        context.setReducedRate(effectiveFromPeriod_, reducedRateScaled_);
     }
 }

--- a/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyScenarioTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyScenarioTest.t.sol
@@ -17,6 +17,7 @@ contract TripleRateYieldStrategyScenarioTest is YieldStrategyScenarioTest {
         context = new TestTripleRateContext(
             DEFAULT_FULL_RATE,
             DEFAULT_REDUCED_RATE,
+            EFFECTIVE_FROM_PERIOD,
             Frequencies.toValue(Frequencies.Frequency.DAYS_365),
             MATURITY_PERIOD,
             DECIMALS
@@ -32,7 +33,7 @@ contract TripleRateYieldStrategyScenarioTest is YieldStrategyScenarioTest {
         return address(context);
     }
 
-    function _setReducedRateAt(uint256 _period, uint256 _reducedRate) internal virtual override {
-        context.setReducedRateAt(_period, _reducedRate);
+    function _setReducedRate(uint256 reducedRateScaled_, uint256 effectiveFromPeriod_) internal virtual override {
+        context.setReducedRate(reducedRateScaled_, effectiveFromPeriod_);
     }
 }

--- a/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyTest.t.sol
@@ -21,6 +21,7 @@ contract TripleRateYieldStrategyTest is Test {
     uint256 public constant DEFAULT_FULL_RATE = PERCENT_10_SCALED;
     uint256 public constant DEFAULT_REDUCED_RATE = PERCENT_5_SCALED;
 
+    uint256 public constant EFFECTIVE_FROM_PERIOD = 0;
     uint256 public constant MATURITY_PERIOD = 30;
 
     uint256 public immutable DEFAULT_FREQUENCY = Frequencies.toValue(Frequencies.Frequency.DAYS_365);
@@ -36,6 +37,7 @@ contract TripleRateYieldStrategyTest is Test {
         context = new TestTripleRateContext(
             DEFAULT_FULL_RATE,
             DEFAULT_REDUCED_RATE,
+            EFFECTIVE_FROM_PERIOD,
             Frequencies.toValue(Frequencies.Frequency.DAYS_365),
             MATURITY_PERIOD,
             DECIMALS
@@ -101,7 +103,7 @@ contract TripleRateYieldStrategyTest is Test {
         );
 
         // Update current tenor at Day 31:
-        context.setReducedRateAt(31, PERCENT_5_5_SCALED);
+        context.setReducedRate(PERCENT_5_5_SCALED, 31);
 
         // 37 Days:
         // ($1,000 * ((10% / 365) * 30) + ($1,000 * ((5.5% / 365) * 7))) = 9.273973

--- a/packages/contracts/test/src/yield/strategy/YieldStrategyScenarioTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/YieldStrategyScenarioTest.t.sol
@@ -19,6 +19,7 @@ abstract contract YieldStrategyScenarioTest is Test {
     uint256 public constant DEFAULT_FULL_RATE = PERCENT_10_SCALED;
     uint256 public constant DEFAULT_REDUCED_RATE = PERCENT_5_SCALED;
 
+    uint256 public constant EFFECTIVE_FROM_PERIOD = 0;
     uint256 public constant MATURITY_PERIOD = 30;
 
     uint256 public immutable DEFAULT_FREQUENCY = Frequencies.toValue(Frequencies.Frequency.DAYS_365);
@@ -30,7 +31,7 @@ abstract contract YieldStrategyScenarioTest is Test {
 
     function _contextAddress() internal virtual returns (address);
 
-    function _setReducedRateAt(uint256 _period, uint256 _reducedRate) internal virtual;
+    function _setReducedRate(uint256 reducedRateScaled_, uint256 effectiveFromPeriod_) internal virtual;
 
     function setUp() public virtual {
         principal = 1_000 * SCALE;
@@ -139,7 +140,7 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  NOTE (JL,2024-09-21): The 45 days above should be 46 days. Raised to Product.
      */
     function test_YieldStrategyScenarioTest_S7() public {
-        _setReducedRateAt(31, PERCENT_5_5_SCALED);
+        _setReducedRate(PERCENT_5_5_SCALED, 31);
         assertApproxEqAbs(
             10_479_452, // Full[30]+Reduced[15] = 8.2191781 + ($1,000 * ((5.5% / 365) * 15) = 10.479452
             _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + 45),
@@ -163,7 +164,7 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  NOTE (JL,2024-09-21): The 50 days above should be 51 days. Raised to Product.
      */
     function test_YieldStrategyScenarioTest_S8() public {
-        _setReducedRateAt(31, PERCENT_5_5_SCALED);
+        _setReducedRate(PERCENT_5_5_SCALED, 31);
         assertApproxEqAbs(
             11_232_876, // Full[30]+Reduced[20] = 8.2191781 + ($1,000 * ((5.5% / 365) * 20) = 11.232876
             _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + 50),
@@ -196,7 +197,7 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  And the yield from the second cycle (8.22 USDC)
      */
     function test_YieldStrategyScenarioTest_S9_S10() public {
-        _setReducedRateAt(31, PERCENT_5_5_SCALED);
+        _setReducedRate(PERCENT_5_5_SCALED, 31);
         assertApproxEqAbs(
             16_438_356, // $1,000 * ((10% / 365) * 60) = 16.438356
             _yieldStrategy().calcYield(
@@ -252,7 +253,7 @@ abstract contract YieldStrategyScenarioTest is Test {
      */
     function test_YieldStrategyScenarioTest_MU2() public {
         // Reduced Rate for second cycle.
-        _setReducedRateAt(31, PERCENT_5_5_SCALED);
+        _setReducedRate(PERCENT_5_5_SCALED, 31);
 
         uint256 redemptionPeriod = 46;
 
@@ -316,7 +317,7 @@ abstract contract YieldStrategyScenarioTest is Test {
      */
     function test_YieldStrategyScenarioTest_MU3() public {
         // Reduced Rate from Day 20 onwards.
-        _setReducedRateAt(20, PERCENT_5_5_SCALED);
+        _setReducedRate(PERCENT_5_5_SCALED, 20);
 
         uint256 redemptionPeriod = 45;
 

--- a/packages/contracts/test/test/yield/context/TestTripleRateContext.t.sol
+++ b/packages/contracts/test/test/yield/context/TestTripleRateContext.t.sol
@@ -5,10 +5,24 @@ import { TripleRateContext } from "@credbull/yield/context/TripleRateContext.sol
 
 contract TestTripleRateContext is TripleRateContext {
     constructor(
-        uint256 fullRateInPercentageScaled_,
-        uint256 reducedRateInPercentageScaled_,
+        uint256 fullRateScaled_,
+        uint256 initialReducedRateScaled_,
+        uint256 initialEffectiveFromPeriod_,
         uint256 frequency_,
         uint256 tenor_,
-        uint256 decimals
-    ) TripleRateContext(fullRateInPercentageScaled_, reducedRateInPercentageScaled_, frequency_, tenor_, decimals) { }
+        uint256 decimals_
+    )
+        TripleRateContext(
+            ContextParams({
+                fullRateScaled: fullRateScaled_,
+                initialReducedRate: PeriodRate({
+                    interestRate: initialReducedRateScaled_,
+                    effectiveFromPeriod: initialEffectiveFromPeriod_
+                }),
+                frequency: frequency_,
+                tenor: tenor_,
+                decimals: decimals_
+            })
+        )
+    { }
 }


### PR DESCRIPTION
### Done
- [x] Realise `ITripleRateContext` in `LiquidContinuousMultiTokenVault` to enable Yield Calculation.
- [x] Update `ITripleRateContext` as requested in review:
    - [x] Use a `struct` in place of a tuple of Interest Rate and associated Effective From Period.
    - [x] Re-name everything 'Tenor Period' to simply 'Tenor Period' as it was confusing. Lots of knock-on changes.
- [x] Update `TripleRateContext` as requested in review:
    - [x] Add and use a `ContextParams` `struct` for `constructor` parameters.
- [x] Access Control of the `setReducedRate` functions.
    - [x] Also, this functions are now Interest Rate-centric, as opposed to Period-centric. A parameter order change.

Replaces PR https://github.com/credbull/credbull-defi/pull/115
Resolves #114 
