### PR TITLE
Ensure that all Yield Calculations are inclusive of the initial period in the range.

### DIFF
--- a/packages/contracts/src/yield/strategy/AbstractYieldStrategy.sol
+++ b/packages/contracts/src/yield/strategy/AbstractYieldStrategy.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { IYieldStrategy } from "@credbull/yield/strategy/IYieldStrategy.sol";
+
+/**
+ * @title AbstractYieldStrategy
+ * @dev Interface for calculating yield and price based on principal and elapsed time periods.
+ */
+abstract contract AbstractYieldStrategy is IYieldStrategy {
+    /**
+     * @notice Calculate the number of periods in effect for Yield Calculation.
+     * @dev Encapsulates the algorithm for determining the number of periods to calculate yield with. The
+     *  number of periods is INCLUSIVE of the `from_` period. Thus the calculation is:
+     *      noOfPeriods = (`to_` - `from_`) + 1
+     *
+     * @param from_ The from period
+     * @param to_ The to period
+     * @return noOfPeriods_ The calculated effective number of periods.
+     */
+    function _noOfPeriods(uint256 from_, uint256 to_) internal pure virtual returns (uint256 noOfPeriods_) {
+        return (to_ - from_) + 1;
+    }
+}

--- a/packages/contracts/src/yield/strategy/SimpleInterestYieldStrategy.sol
+++ b/packages/contracts/src/yield/strategy/SimpleInterestYieldStrategy.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.20;
 
 import { ICalcInterestMetadata } from "@credbull/yield/ICalcInterestMetadata.sol";
 import { CalcSimpleInterest } from "@credbull/yield/CalcSimpleInterest.sol";
-import { IYieldStrategy } from "@credbull/yield/strategy/IYieldStrategy.sol";
+import { AbstractYieldStrategy } from "@credbull/yield/strategy/AbstractYieldStrategy.sol";
 
 /**
  * @title SimpleInterestYieldStrategy
  * @dev Strategy where returns are calculated using SimpleInterest
  */
-contract SimpleInterestYieldStrategy is IYieldStrategy {
+contract SimpleInterestYieldStrategy is AbstractYieldStrategy {
     /// @dev See {CalcSimpleInterest-calcInterest}
     function calcYield(address contextContract, uint256 principal, uint256 fromPeriod, uint256 toPeriod)
         public
@@ -25,7 +25,7 @@ contract SimpleInterestYieldStrategy is IYieldStrategy {
         }
         ICalcInterestMetadata interestData = ICalcInterestMetadata(contextContract);
 
-        uint256 numPeriodsElapsed = toPeriod - fromPeriod;
+        uint256 numPeriodsElapsed = _noOfPeriods(fromPeriod, toPeriod);
 
         return CalcSimpleInterest.calcInterest(
             principal, interestData.rateScaled(), numPeriodsElapsed, interestData.frequency(), interestData.scale()

--- a/packages/contracts/src/yield/strategy/TripleRateYieldStrategy.sol
+++ b/packages/contracts/src/yield/strategy/TripleRateYieldStrategy.sol
@@ -3,14 +3,16 @@ pragma solidity ^0.8.20;
 
 import { ITripleRateContext } from "@credbull/yield/context/ITripleRateContext.sol";
 import { CalcSimpleInterest } from "@credbull/yield/CalcSimpleInterest.sol";
+// solhint-disable-next-line no-unused-import
 import { IYieldStrategy } from "@credbull/yield/strategy/IYieldStrategy.sol";
+import { AbstractYieldStrategy } from "@credbull/yield/strategy/AbstractYieldStrategy.sol";
 
 /**
  * @title TripleRateYieldStrategy
  * @dev Calculates returns using 1 'full' rate and 2 'reduced' rates, applied according to the Tenor Period, and
  *  depending on the holding period.
  */
-contract TripleRateYieldStrategy is IYieldStrategy {
+contract TripleRateYieldStrategy is AbstractYieldStrategy {
     /**
      * @inheritdoc IYieldStrategy
      */
@@ -31,32 +33,41 @@ contract TripleRateYieldStrategy is IYieldStrategy {
 
         // Calculate interest for full-rate periods
         uint256 noOfFullRatePeriods = _noOfFullRatePeriods(context.numPeriodsForFullRate(), fromPeriod, toPeriod);
-        yield = CalcSimpleInterest.calcInterest(
-            principal, context.rateScaled(), noOfFullRatePeriods, context.frequency(), context.scale()
-        );
+        if (noOfFullRatePeriods > 0) {
+            yield = CalcSimpleInterest.calcInterest(
+                principal, context.rateScaled(), noOfFullRatePeriods, context.frequency(), context.scale()
+            );
+        }
 
         // Calculate interest for reduced-rate periods
         if (_noOfPeriods(fromPeriod, toPeriod) - noOfFullRatePeriods > 0) {
             uint256 firstReducedRatePeriod = _firstReducedRatePeriod(noOfFullRatePeriods, fromPeriod);
             ITripleRateContext.PeriodRate memory currentPeriodRate = context.currentPeriodRate();
 
-            // Previous Tenor Period ... Current Tenor Period ... 1st Reduced Rate Period ... To Period
-            // If the 1st RR Period is on or after the current Tenor Period, then RR Interest is:
-            //  1st RR Period -> To Period @ Current Rate.
+            // Previous Period Rate -> Current Period Rate -> 1st Reduced Rate Period -> To Period
+            // If the first 'reduced' interest rate period (FRRP) is on or after the current Period Rate, then the
+            // 'reduced' Yield is:
+            //  (FRRP -> To Period) + 1 @ Current Rate.
+            // The '+ 1' is because the calculation is inclusive of the FRRP.
             if (firstReducedRatePeriod >= currentPeriodRate.effectiveFromPeriod) {
                 //  1st RR Period -> To Period @ Current Rate.
                 yield += CalcSimpleInterest.calcInterest(
                     principal,
                     currentPeriodRate.interestRate,
-                    toPeriod - firstReducedRatePeriod,
+                    (toPeriod - firstReducedRatePeriod) + 1,
                     context.frequency(),
                     context.scale()
                 );
             }
-            // Previous Tenor Period ... 1st Reduced Rate Period ... Current Tenor Period ... To Period
-            // If the 1st RR Period is on or after the previous Tenor Period, then RR Interest is:
-            //  1st RR Period -> Current Period @ Previous Rate +
-            //  Current Period -> To Period @ Current Rate.
+            // Previous Period Rate -> 1st Reduced Rate Period -> Current Period Rate -> To Period
+            // If the FRRP is on or after the previous Period Rate, then the 'reduced' Yield is:
+            //  (FRRP -> Current Period Rate - 1) + 1 @ Previous Rate +
+            //  (Current Period -> To Period) + 1 @ Current Rate.
+            // The '- 1' is because the Previous Period Rate applies up to but exclusive of the Current Period Rate.
+            // The '+ 1' is because the calculation is inclusive of the first day of any period span.
+            // Of course, the `+/- 1`s cancel each other out and we are left with:
+            //  FRRP -> Current Period Rate @ Previous Rate +
+            //  (Current Period Rate -> To Period) + 1 @ Current Rate.
             else {
                 ITripleRateContext.PeriodRate memory previousPeriodRate = context.previousPeriodRate();
 
@@ -73,7 +84,7 @@ contract TripleRateYieldStrategy is IYieldStrategy {
                 yield += CalcSimpleInterest.calcInterest(
                     principal,
                     currentPeriodRate.interestRate,
-                    toPeriod - currentPeriodRate.effectiveFromPeriod,
+                    (toPeriod - currentPeriodRate.effectiveFromPeriod) + 1,
                     context.frequency(),
                     context.scale()
                 );
@@ -101,41 +112,34 @@ contract TripleRateYieldStrategy is IYieldStrategy {
     }
 
     /**
-     * @dev Utility function to calculate the Number Of Periods between `from_` and `to_`. Also reduces Stack Depth in
-     *  invoking functions.
+     * @notice Calculates the number of 'full' Interest Rate Periods.
      *
+     * @param noOfPeriodsForFullRate_  The number of periods that apply for the 'full' Interest Rate.
      * @param from_ The from period
      * @param to_ The to period
+     * @return The calculated number of 'full' Interest Rate Periods.
      */
-    function _noOfPeriods(uint256 from_, uint256 to_) internal pure returns (uint256) {
-        return to_ - from_;
-    }
-
-    /**
-     * @dev Calculates the number of Full Rate Periods.
-     *
-     * @param _noOfPeriodsForFullRate  The number of periods that apply for Full Rate.
-     * @param _from The from period
-     * @param _to The to period
-     * @return The calculated number of Full Rate Periods.
-     */
-    function _noOfFullRatePeriods(uint256 _noOfPeriodsForFullRate, uint256 _from, uint256 _to)
+    function _noOfFullRatePeriods(uint256 noOfPeriodsForFullRate_, uint256 from_, uint256 to_)
         internal
         pure
         returns (uint256)
     {
-        uint256 _periods = _noOfPeriods(_from, _to);
-        return _periods - (_periods % _noOfPeriodsForFullRate);
+        uint256 _periods = _noOfPeriods(from_, to_);
+        return _periods - (_periods % noOfPeriodsForFullRate_);
     }
 
     /**
-     * @dev Calculates the first Reduced Rate Period.
+     * @notice Calculates the first 'reduced' Interest Rate Period after the `_from` period.
+     * @dev Encapsulates the algorithm that determines the first 'reduced' Interest Rate Period. Given that `from_`
+     *  period is INCLUSIVE, this means the calculation, IFF there are 'full' Interest Rate periods, is:
+     *      `from_` + `noOfFullRatePeriods_`
+     *  Otherwise, it is simply the `from_` value.
      *
      * @param noOfFullRatePeriods_  The number of Full Rate Periods
-     * @param _from  The from period.
+     * @param from_  The from period.
      * @return The calculated first Reduced Rate Period.
      */
-    function _firstReducedRatePeriod(uint256 noOfFullRatePeriods_, uint256 _from) internal pure returns (uint256) {
-        return noOfFullRatePeriods_ != 0 ? _from + noOfFullRatePeriods_ : _from;
+    function _firstReducedRatePeriod(uint256 noOfFullRatePeriods_, uint256 from_) internal pure returns (uint256) {
+        return noOfFullRatePeriods_ != 0 ? from_ + noOfFullRatePeriods_ : from_;
     }
 }

--- a/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
+++ b/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
@@ -47,7 +47,7 @@ contract LiquidContinuousMultiTokenVaultTest is IMultiTokenVaultTestBase {
         LiquidContinuousMultiTokenVaultMock liquidVault = _createLiquidContinueMultiTokenVault(_vaultParams);
 
         IMultiTokenVaultTestParams memory testParams =
-            IMultiTokenVaultTestParams({ principal: 2_000 * _scale, depositPeriod: 11, redeemPeriod: 71 });
+            IMultiTokenVaultTestParams({ principal: 2_000 * _scale, depositPeriod: 11, redeemPeriod: 70 });
 
         uint256 assetStartBalance = _asset.balanceOf(alice);
 

--- a/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
+++ b/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
@@ -108,15 +108,15 @@ contract LiquidContinuousMultiTokenVaultTest is IMultiTokenVaultTestBase {
         uint256 deposit = 50_000 * _scale;
 
         // verify returns
-        uint256 actualYield = _liquidVault.calcYield(deposit, 0, _liquidVault.TENOR());
+        uint256 actualYield = _liquidVault.calcYield(deposit, 0, _liquidVault.TENOR() - 1);
         assertEq(416_666666, actualYield, "interest not correct for $50k deposit after 30 days");
 
         // verify principal + returns
         uint256 actualShares = _liquidVault.convertToShares(deposit);
-        uint256 actualReturns = _liquidVault.convertToAssetsForDepositPeriod(actualShares, 0, _liquidVault.TENOR());
+        uint256 actualReturns = _liquidVault.convertToAssetsForDepositPeriod(actualShares, 0, _liquidVault.TENOR() - 1);
         assertEq(50_416_666666, actualReturns, "principal + interest not correct for $50k deposit after 30 days");
 
-        testVaultAtPeriods(_liquidVault, deposit, 0, _liquidVault.TENOR());
+        testVaultAtPeriods(_liquidVault, deposit, 0, _liquidVault.TENOR() - 1);
     }
 
     function test__LiquidContinuousVaultTest__Upgradeability() public {

--- a/packages/contracts/test/src/yield/strategy/AbstractYieldStrategyTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/AbstractYieldStrategyTest.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import { AbstractYieldStrategy } from "@credbull/yield/strategy/AbstractYieldStrategy.sol";
+
+import { Test } from "forge-std/Test.sol";
+
+contract AbstractYieldStrategyTest is AbstractYieldStrategy, Test {
+    uint256 public constant TOLERANCE = 1; // with 6 decimals, diff of 0.000001
+
+    uint256 public constant DECIMALS = 6;
+    uint256 public constant SCALE = 10 ** DECIMALS;
+
+    function test_AbstractYieldStrategyTest_NoOfPeriodsCalculation(uint256 from_, uint256 to_) public pure {
+        vm.assume(to_ > from_);
+        vm.assume(to_ < type(uint256).max);
+
+        assertEq(
+            (to_ - from_) + 1,
+            _noOfPeriods(from_, to_),
+            string.concat(
+                "Incorrect No Of Periods: From: ",
+                string.concat(vm.toString(from_), string.concat(", To: ", vm.toString(to_)))
+            )
+        );
+    }
+
+    /// @dev No impl stub.
+    function calcYield(
+        address, /* contextContract */
+        uint256, /* principal */
+        uint256, /* fromTimePeriod */
+        uint256 /* toTimePeriod */
+    ) external pure override returns (uint256 yield) {
+        return 0;
+    }
+
+    /// @dev No impl stub.
+    function calcPrice(address, /* contextContract */ uint256 /* numTimePeriodsElapsed */ )
+        external
+        pure
+        override
+        returns (uint256 price)
+    {
+        return 0;
+    }
+}

--- a/packages/contracts/test/src/yield/strategy/SimpleInterestYieldStrategyTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/SimpleInterestYieldStrategyTest.t.sol
@@ -27,28 +27,32 @@ contract SimpleInterestYieldStrategyTest is Test {
 
         uint256 principal = 500 * SCALE;
 
+        // 500 * (6% / 360) * 2
         assertApproxEqAbs(
-            83_333,
+            166_666,
             yieldStrategy.calcYield(interestContractAddress, principal, 0, 1),
             TOLERANCE,
             "yield wrong at period 0 to 1"
         );
+        // 500 * (6% / 360) * 3
         assertApproxEqAbs(
-            166_666,
+            250_000,
             yieldStrategy.calcYield(interestContractAddress, principal, 1, 3),
             TOLERANCE,
             "yield wrong at period 1 to 3"
         );
+        // 500 * (6% / 360) * 31
         assertApproxEqAbs(
-            2_500_000,
+            2_583_333,
             yieldStrategy.calcYield(interestContractAddress, principal, 1, 31),
             TOLERANCE,
             "yield wrong at period 1 to 31"
         );
 
         address interest2Addr = address(_createInterestMetadata(apy * 2, frequency)); // double the interest rate
+        // 500 * (12% / 360) * 31
         assertApproxEqAbs(
-            5_000_000, // yield should also double
+            5_166_667, // yield should also double
             yieldStrategy.calcYield(interest2Addr, principal, 1, 31),
             TOLERANCE,
             "yield wrong at period 1 to 31 - double APY"

--- a/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyTest.t.sol
@@ -31,7 +31,6 @@ contract TripleRateYieldStrategyTest is Test {
     TestTripleRateContext internal context;
     address internal contextAddress;
     uint256 internal principal;
-    uint256 internal depositPeriod;
 
     function setUp() public {
         yieldStrategy = new TripleRateYieldStrategy();
@@ -54,12 +53,11 @@ contract TripleRateYieldStrategyTest is Test {
         );
         contextAddress = address(context);
         principal = 1_000 * SCALE;
-        depositPeriod = 1;
     }
 
     function test_TripleRateYieldStrategy_RevertCalcYield_WhenInvalidContextAddress() public {
         vm.expectRevert(IYieldStrategy.IYieldStrategy_InvalidContextAddress.selector);
-        yieldStrategy.calcYield(address(0), principal, depositPeriod, depositPeriod + MATURITY_PERIOD);
+        yieldStrategy.calcYield(address(0), principal, 1, MATURITY_PERIOD);
     }
 
     function test_TripleRateYieldStrategy_RevertCalcPrice_WhenInvalidContextAddress() public {
@@ -69,7 +67,7 @@ contract TripleRateYieldStrategyTest is Test {
 
     function test_TripleRateYieldStrategy_RevertCalcYield_WhenInvalidPeriodRange() public {
         vm.expectRevert(abi.encodeWithSelector(IYieldStrategy.IYieldStrategy_InvalidPeriodRange.selector, 1, 1));
-        yieldStrategy.calcYield(contextAddress, principal, depositPeriod, depositPeriod);
+        yieldStrategy.calcYield(contextAddress, principal, 1, 1);
 
         vm.expectRevert(abi.encodeWithSelector(IYieldStrategy.IYieldStrategy_InvalidPeriodRange.selector, 5, 3));
         yieldStrategy.calcYield(contextAddress, principal, 5, 3);
@@ -80,7 +78,7 @@ contract TripleRateYieldStrategyTest is Test {
         // $1,000 * ((5% / 365) * 21) = 2.876712
         assertApproxEqAbs(
             2_876_712,
-            yieldStrategy.calcYield(contextAddress, principal, depositPeriod, depositPeriod + 21),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 21),
             TOLERANCE,
             "incorrect 21 day reduced rate yield"
         );
@@ -89,7 +87,7 @@ contract TripleRateYieldStrategyTest is Test {
         // $1,000 * ((5% / 365) * 29) = 3.972603
         assertApproxEqAbs(
             3_972_603,
-            yieldStrategy.calcYield(contextAddress, principal, depositPeriod, depositPeriod + 29),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 29),
             TOLERANCE,
             "incorrect 29 day reduced rate yield"
         );
@@ -98,7 +96,7 @@ contract TripleRateYieldStrategyTest is Test {
         // $1,000 * ((10% / 365) * 30) = 8.219178
         assertApproxEqAbs(
             8_219_178,
-            yieldStrategy.calcYield(contextAddress, principal, depositPeriod, depositPeriod + 30),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 30),
             TOLERANCE,
             "incorrect 30 day full rate yield"
         );
@@ -107,7 +105,7 @@ contract TripleRateYieldStrategyTest is Test {
         // ($1,000 * ((10% / 365) * 30) + ($1,000 * ((5% / 365) * 2))) = 8.493151
         assertApproxEqAbs(
             8_493_151,
-            yieldStrategy.calcYield(contextAddress, principal, depositPeriod, depositPeriod + 32),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 32),
             TOLERANCE,
             "incorrect 32 day combined rate yield"
         );
@@ -119,17 +117,16 @@ contract TripleRateYieldStrategyTest is Test {
         // ($1,000 * ((10% / 365) * 30) + ($1,000 * ((5.5% / 365) * 7))) = 9.273973
         assertApproxEqAbs(
             9_273_973,
-            yieldStrategy.calcYield(contextAddress, principal, depositPeriod, depositPeriod + 37),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 37),
             TOLERANCE,
             "incorrect 37 day combined rate yield"
         );
 
         // 22 Days, across Current Tenor Period:
-        depositPeriod = 20;
         // ($1,000 * ((5% / 365) * 11) + ($1,000 * ((5.5% / 365) * 11))) = 3.164384
         assertApproxEqAbs(
             3_164_384,
-            yieldStrategy.calcYield(contextAddress, principal, depositPeriod, depositPeriod + 22),
+            yieldStrategy.calcYield(contextAddress, principal, 20, 41),
             TOLERANCE,
             "incorrect 22 day across tenor periods rate yield"
         );

--- a/packages/contracts/test/src/yield/strategy/YieldStrategyScenarioTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/YieldStrategyScenarioTest.t.sol
@@ -39,18 +39,23 @@ abstract contract YieldStrategyScenarioTest is Test {
     }
 
     /**
-     * S1
+     * # S1
      * Scenario: User deposits 1000 USDC and redeems the APY before maturity
      *  Given a user has deposited 1000 USDC into LiquidStone Plume
      *  And the T-Bill Rate is 5%
      *  When the user requests to redeem the APY after 15 days
      *  Then the user should receive the prorated yield (2.055 USDC)
      *  And the principal should remain in the vault
+     *
+     * Calculation:
+     *  Daily yield rate = 5% / 365 = 0.0137%
+     *  Yield for 15 days = 1000 * 0.0137% * 15 = 2.055 USDC
      */
     function test_YieldStrategyScenarioTest_S1() public {
+        // $1,000 * ((5% / 365) * 15) =  2.054794
         assertEq(
-            2_054_794, // $1,000 * ((5% / 365) * 15) =  2.054794
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + 15),
+            2_054_794,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 15),
             "reduced rate yield wrong at deposit + 15 days"
         );
     }
@@ -63,11 +68,17 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  When the user requests to redeem the Principal after 20 days
      *  Then the user should receive their principal of 1000 USDC
      *  And the prorated yield based on the T-Bill Rate (2.74 USDC)
+     *
+     * Calculation:
+     *  Daily yield rate = 5% / 365 = 0.0137%
+     *  Yield for 20 days = 1000 * 0.0137% * 20 = 2.74 USDC
+     *  Total redemption = 1000 + 2.74 = 1002.74 USDC
      */
     function test_YieldStrategyScenarioTest_S2() public {
+        // $1,000 * ((5% / 365) * 20) =  2.739726
         assertEq(
-            2_739_726, // $1,000 * ((5% / 365) * 20) =  2.739726
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + 20),
+            2_739_726,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 20),
             "reduced rate yield wrong at deposit + 20 days"
         );
     }
@@ -77,24 +88,32 @@ abstract contract YieldStrategyScenarioTest is Test {
      * Scenario: User deposits 1000 USDC and redeems the APY after maturity
      *  Given a user has deposited 1000 USDC into LiquidStone Plume
      *  And the T-Bill Rate is 5% for the first 29 days
-     *  And the APY jumps to 10% on day 30
+     *  And the APY jumps to 10% on day 31
      *  When the user requests to redeem the APY after 30 days
      *  Then the user should receive the yield based on 10% APY (8.22 USDC)
      *  And the principal should remain in the vault
+     *
+     * Calculation:
+     *  Yield for 30 days at 10% APY = 1000 * (10% / 365) * 30 = 8.22 USDC
      *
      * S4
      * Scenario: User deposits 1000 USDC and redeems the Principal after maturity
      *  Given a user has deposited 1000 USDC into LiquidStone Plume
      *  And the T-Bill Rate is 5% for the first 29 days
-     *  And the APY jumps to 10% on day 30
+     *  And the APY jumps to 10% on day 31
      *  When the user requests to redeem the Principal after 30 days
      *  Then the user should receive their principal of 1000 USDC
      *  And the yield based on 10% APY (8.22 USDC)
+     *
+     * Calculation:
+     *  Yield for 30 days at 10% APY = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *  Total redemption = 1000 + 8.22 = 1008.22 USDC
      */
     function test_YieldStrategyScenarioTest_S3_S4() public {
+        // $1,000 * ((10% / 365) * 30) = 8.219178
         assertEq(
-            8_219_178, // $1,000 * ((10% / 365) * 30) = 8.219178
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + MATURITY_PERIOD),
+            8_219_178,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, MATURITY_PERIOD),
             "fully rate yield wrong at deposit + maturity days"
         );
     }
@@ -137,13 +156,18 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  And the prorated yield from the second cycle (2.26 USDC)
      *  And the principal should remain in the vault
      *
-     *  NOTE (JL,2024-09-21): The 45 days above should be 46 days. Raised to Product.
+     * Calculation:
+     *  First cycle yield (30 days at 10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *  Second cycle partial yield (15 days at 5.5%) = 1000 * (5.5% / 365) * 15 = 2.26 USDC
+     *  Total yield = 8.22 + 2.26 = 10.48 USDC
      */
     function test_YieldStrategyScenarioTest_S7() public {
         _setReducedRate(PERCENT_5_5_SCALED, 31);
+
+        // $1,000 * ((10% / 365) * 30) + $1,000 * ((5.5% / 365) * 15) = 10.479452
         assertApproxEqAbs(
-            10_479_452, // Full[30]+Reduced[15] = 8.2191781 + ($1,000 * ((5.5% / 365) * 15) = 10.479452
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + 45),
+            10_479_452,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 45),
             TOLERANCE,
             "full + reduced rate yield wrong at deposit + 45 days"
         );
@@ -161,13 +185,18 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  And the yield from the first cycle (8.22 USDC)
      *  And the prorated yield from the second cycle (3.01 USDC)
      *
-     *  NOTE (JL,2024-09-21): The 50 days above should be 51 days. Raised to Product.
+     * Calculation:
+     *  First cycle yield (30 days at 10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *  Second cycle partial yield (20 days at 5.5%) = 1000 * (5.5% / 365) * 20 = 3.01 USDC
+     *  Total redemption = 1000 + 8.22 + 3.01 = 1011.23 USDC
      */
     function test_YieldStrategyScenarioTest_S8() public {
         _setReducedRate(PERCENT_5_5_SCALED, 31);
+
+        // $1,000 * ((10% / 365) * 30) + $1,000 * ((5.5% / 365) * 20) = 11.232876
         assertApproxEqAbs(
-            11_232_876, // Full[30]+Reduced[20] = 8.2191781 + ($1,000 * ((5.5% / 365) * 20) = 11.232876
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + 50),
+            11_232_876,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 50),
             TOLERANCE,
             "full + reduced rate yield wrong at deposit + 50 days"
         );
@@ -185,6 +214,11 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  And the yield from the second cycle (8.22 USDC)
      *  And the principal should remain in the vault
      *
+     * Calculation:
+     *  First cycle yield (30 days at 10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *  Second cycle yield (30 days at 10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *  Total yield = 8.22 + 8.22 = 16.44 USDC
+     *
      * S10
      * Scenario: User deposits 1000 USD, retains for extra cycle, redeems the Principal after new cycle ends
      *  Given a user has deposited 1000 USDC into LiquidStone Plume
@@ -195,14 +229,19 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  Then the user should receive their principal of 1000 USDC
      *  And the yield from the first cycle (8.22 USDC)
      *  And the yield from the second cycle (8.22 USDC)
+     *
+     * Calculation:
+     *  First cycle yield (30 days at 10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *  Second cycle yield (30 days at 10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *  Total redemption = 1000 + 8.22 + 8.22 = 1016.44 USDC
      */
     function test_YieldStrategyScenarioTest_S9_S10() public {
         _setReducedRate(PERCENT_5_5_SCALED, 31);
+
+        // $1,000 * ((10% / 365) * 60) = 16.438356
         assertApproxEqAbs(
-            16_438_356, // $1,000 * ((10% / 365) * 60) = 16.438356
-            _yieldStrategy().calcYield(
-                _contextAddress(), principal, depositPeriod, depositPeriod + (2 * MATURITY_PERIOD)
-            ),
+            16_438_356,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, (2 * MATURITY_PERIOD)),
             TOLERANCE,
             "full rate yield wrong at deposit + 2x maturity"
         );
@@ -217,24 +256,33 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  When both users redeem their investments on day 31
      *  Then User A should receive 10% APY on their investment
      *  And User B should receive 5% APY on their investment
+     *
+     * Calculation:
+     *  User A redemption = 1000 + (1000 * 10% * 30/365) = 1008.22 USDC
+     *  User B redemption = 1000 + (1000 * 5% * 15/365) = 1002.05 USDC
+     *
+     * NOTE (JL,2024-10-03): As deposit day is inclusive for yield calculation, for User A redeeming on Day 30 is
+     *  1 Tenor/Maturity Period and yields 10% APY.
+     *  For User B, depositing on Day 15 and redeeming on Day 30 is actually 16 days.
+     *  Communicated to product.
      */
     function test_YieldStrategyScenarioTest_MU1() public {
         // User A
+        // Deposit on Day 1, Redeem Day 30 = 30 days at full rate.
+        // $1,000 * ((10% / 365) * 30) = 8.219718
         assertApproxEqAbs(
-            8_219_178, // $1,000 * ((10% / 365) * 30) = 8.219718
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, depositPeriod + MATURITY_PERIOD),
+            8_219_178,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, MATURITY_PERIOD),
             TOLERANCE,
             "full rate yield wrong at deposit + maturity"
         );
 
         // User B
-        // Deposit on Day 15, Redeem Day 31 = 16 days at reduced rate.
-        uint256 depositPeriodUserB = 15;
+        // Deposit on Day 15, Redeem Day 30 = 16 days at reduced rate.
+        // $1,000 * ((5% / 365) * 16) = 2.191780
         assertApproxEqAbs(
-            2_191_780, // $1,000 * ((5% / 365) * 16) = 2.191780
-            _yieldStrategy().calcYield(
-                _contextAddress(), principal, depositPeriodUserB, depositPeriod + MATURITY_PERIOD
-            ),
+            2_191_780,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 15, MATURITY_PERIOD),
             TOLERANCE,
             "reduced rate yield wrong at deposit + 15 days"
         );
@@ -250,28 +298,36 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  When both users redeem their investments 15 days after day 31
      *  Then User A should receive 10% APY for the first 30 days and 5.5% for the next 15 days
      *  And User B should receive 10% APY for the full 30 days
+     *
+     * Calculation:
+     *  User A redemption = 1000 + (1000 * 10% * 30/365) + (1000 * 5.5% * 15/365) = 1010.48 USDC
+     *  User B redemption = 1000 + (1000 * 10% * 30/365) = 1008.22 USDC
+     *
+     * NOTE (JL,2024-10-03): As deposit day is inclusive for yield calculation, for User A redeeming on Day 46 is
+     *  1 Maturity Period @ 10% APY and 16 days @ 5.5% APY.
+     *  For User B, depositing on Day 15 and redeeming on Day 46 is 1 Maturity Period @ 10% APY and 2 days @ 5.5% APY.
+     *  Communicated to product.
      */
     function test_YieldStrategyScenarioTest_MU2() public {
         // Reduced Rate for second cycle.
         _setReducedRate(PERCENT_5_5_SCALED, 31);
 
-        uint256 redemptionPeriod = 46;
-
         // User A
+        // Deposit on Day 1, Redeem Day 46 = 30 days at full rate and 16 days at reduced rate.
+        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 16) = 10.630137
         assertApproxEqAbs(
-            10_479_452, // Full[30]+Reduced[15] = 8.219178 + ($1,000 * ((5.5% / 365) * 15) = 10.479452
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, redemptionPeriod),
+            10_630_137,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 46),
             TOLERANCE,
             "full + reduced rate yield wrong at deposit + maturity + 15"
         );
 
         // User B
-        // Deposit on Day 15, Redeem Day 46 = 1 full rate and 1 day at reduced rate.
-        // Deposit on Day 16, Redeem Day 46 = 1 fullrate
-        uint256 depositPeriodUserB = 16;
+        // Deposit on Day 15, Redeem Day 46 = 1 full rate and 2 days at reduced rate.
+        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 2) = 8.520548
         assertApproxEqAbs(
-            8_219_178, // $1,000 * ((10% / 365) * 30) = 8.219178
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriodUserB, redemptionPeriod),
+            8_520_548,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 15, 46),
             TOLERANCE,
             "full rate yield wrong at deposit + maturity"
         );
@@ -280,7 +336,7 @@ abstract contract YieldStrategyScenarioTest is Test {
     /**
      * MU-3
      * Scenario: Two users deposit at different funding round, with different T-Bill Rates, both redeem 14 days after
-     *      day 31 (day 1 and day 15)
+     *         day 31 (day 1 and day 15)
      *  Given User A deposits 1000 USDC on day 1
      *  And User B deposits 1000 USDC on day 15
      *  And the T-Bill Rate is 5% from day 1 to day 20
@@ -289,53 +345,41 @@ abstract contract YieldStrategyScenarioTest is Test {
      *  Then User A should receive 1010.33 USDC
      *  And User B should receive 1004.30 USDC
      *
-     * SHOULD BE:
-     *
-     * Scenario: Two users deposit at different funding round, with different T-Bill Rates, both redeem 14 days after
-     *      day 31 (day 1 and day 15)
-     *  Given User A deposits 1000 USDC on day 1
-     *  And User B deposits 1000 USDC on day 16
-     *  And the T-Bill Rate is 5% from day 1 to day 19
-     *  And the T-Bill Rate is 5.5% from day 20 to day 45
-     *  When both users redeem on day 45
-     *  Then User A should receive 1010.33 USDC
-     *  And User B should receive 1004.32 USDC
-     *
      * Calculation:
-     * User A:
-     * First 30 days yield (10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
-     * Remaining 14 days yield (5.5% APY) = 1000 * (5.5% / 365) * 14 = 2.11 USDC
-     * Total yield = 8.22 + 2.11 = 10.33 USDC
-     * Total redemption = 1000 + 10.33 = 1010.33 USDC
+     *  User A:
+     *   First 30 days yield (10% APY) = 1000 * (10% / 365) * 30 = 8.22 USDC
+     *   Remaining 14 days yield (5.5% APY) = 1000 * (5.5% / 365) * 14 = 2.11 USDC
+     *   Total yield = 8.22 + 2.11 = 10.33 USDC
+     *   Total redemption = 1000 + 10.33 = 1010.33 USDC
      *
-     * User B:
-     * First 4 days yield (5% APY) = 1000 * (5% / 365) * 4 = 0.0.55 USDC
-     * Next 25 days yield (5.5% APY) = 1000 * (5.5% / 365) * 25 = 3.77 USDC
-     * Total yield = 0.55 + 3.77 = 4.32 USDC
-     * Total redemption = 1000 + 4.32 = 1004.32 USDC
+     *  User B:
+     *   First 5 days yield (5% APY) = 1000 * (5% / 365) * 5 = 0.68 USDC
+     *   Next 24 days yield (5.5% APY) = 1000 * (5.5% / 365) * 24 = 3.62 USDC
+     *   Total yield = 0.68 + 3.62 = 4.30 USDC
+     *   Total redemption = 1000 + 4.30 = 1004.30 USDC
      *
+     * NOTE (JL,2024-10-03): Exact numbers and calculations modified to capture the spirit of the Scenario.
      */
     function test_YieldStrategyScenarioTest_MU3() public {
         // Reduced Rate from Day 20 onwards.
         _setReducedRate(PERCENT_5_5_SCALED, 20);
 
-        uint256 redemptionPeriod = 45;
-
         // User A
+        // Deposit on Day 1, Redeem Day 45 = 30 days at full rate and 15 days at 5.5% APY.
+        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 15) = 10.479452
         assertApproxEqAbs(
-            10_328_767, // Full[30]+Reduced[14] = 8.219178 + ($1,000 * ((5.5% / 365) * 14) = 10.328767
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriod, redemptionPeriod),
+            10_479_452,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 45),
             TOLERANCE,
             "full + reduced rate yield wrong at deposit + maturity + 15"
         );
 
         // User B
-        // Deposit on Day 15, Redeem Day 45 = 30 days at full rate.
-        // Deposit on Day 16, Redeem Day 45 = 29 days at reduced rate. The desired scenario!
-        uint256 depositPeriodUserB = 16;
+        // Deposit on Day 17, Redeem Day 45 = 29 days at reduced rates.
+        // $1,000 * ((5% / 365) * 3) + $1,000 * ((5.5% / 365) * 26) = 4.328767
         assertApproxEqAbs(
-            4_315_068, // ($1,000 * ((5% / 365) * 4)) + ($1,000 * ((5.5% / 365) * 25)) = 4.315068
-            _yieldStrategy().calcYield(_contextAddress(), principal, depositPeriodUserB, redemptionPeriod),
+            4_328_767,
+            _yieldStrategy().calcYield(_contextAddress(), principal, 17, 45),
             TOLERANCE,
             "reduced rate yield wrong at deposit + 29"
         );


### PR DESCRIPTION
### Abstract
As per the spec, when applying a range of periods to a Yield Calculation, then the start period is inclusive. Thus, if calculating yield for a deposit on Period 10 and redeem on Period 19, this is 10 periods. The calculation is:  _(to - from) + 1_

### Done
- [x] Added the `AbstractYieldStrategy` to encapsulate the `_noOfPeriods()` function which determines the number of periods, between a `from` and a `to` period, that are valid for yield calculation. All `IYieldStrategy` realisations can extend this `abstract contract`.
- [x] Assessed all other functionality that works with a from/deposit period and a to/redeem period. This functionality seems fine, as it does not calculate period ranges, as the periods tend to behave as Token Ids.
- [x] Fixed all tests to use period ranges in the spirit of the test themselves.
- [x] Updated the `YieldStrategyScenarioTest` to use the latest product spec terms and fulfil the tests correctly.
