### PR TITLE
Improve the `RedeemOptimizerFIFO` loops.

### DIFF
--- a/packages/contracts/src/token/ERC1155/RedeemOptimizerFIFO.sol
+++ b/packages/contracts/src/token/ERC1155/RedeemOptimizerFIFO.sol
@@ -73,14 +73,12 @@ contract RedeemOptimizerFIFO is IRedeemOptimizer {
         }
 
         console.log("_amountsAtPeriods(): Current Period= %d", vault.currentPeriodsElapsed());
-
-        uint256 currentPeriod = vault.currentPeriodsElapsed();
-        if (toDepositPeriod > currentPeriod) {
-            revert RedeemOptimizer__FutureToDepositPeriod(toDepositPeriod, currentPeriod);
+        if (toDepositPeriod > vault.currentPeriodsElapsed()) {
+            revert RedeemOptimizer__FutureToDepositPeriod(toDepositPeriod, vault.currentPeriodsElapsed());
         }
 
         console.log(
-            "_amountsAtPeriods(): MaxAmount= %d, From= %d, To= %d", maxAmount, fromDepositPeriod, toDepositPeriod
+            "_amountsAtPeriods(): To Find= %d, From= %d, To= %d", amountToFind, fromDepositPeriod, toDepositPeriod
         );
         console.log(
             "_amountsAtPeriods(): No Of Periods= %d, Amount Type= ",
@@ -112,8 +110,9 @@ contract RedeemOptimizerFIFO is IRedeemOptimizer {
 
                 // check if we will go "over" the max amount
                 if ((amountFound + amountAtPeriod) > amountToFind) {
-                    cacheAmountAtPeriods[arrayIndex++] = maxAmount - amountFound; // include only the partial amount
-                    console.log("_amountsAtPeriods(): Partial= %d", cacheAmountAtPeriods[arrayIndex - 1]);
+                    cacheAmountAtPeriods[arrayIndex] = amountToFind - amountFound; // include only the partial amount
+                    console.log("_amountsAtPeriods(): Partial= %d", cacheAmountAtPeriods[arrayIndex]);
+                    amountFound += cacheAmountAtPeriods[arrayIndex++];
                     break; // we're done, no need to keep looping
                 } else {
                     cacheAmountAtPeriods[arrayIndex] = amountAtPeriod;

--- a/packages/contracts/src/token/ERC1155/RedeemOptimizerFIFO.sol
+++ b/packages/contracts/src/token/ERC1155/RedeemOptimizerFIFO.sol
@@ -88,8 +88,8 @@ contract RedeemOptimizerFIFO is IRedeemOptimizer {
             if (amountAtPeriod > 0) {
                 cacheDepositPeriods[arrayIndex] = depositPeriod;
 
-                // check if we will go "over" the max amount
-                if ((amountFound + amountAtPeriod) > amountToFind) {
+                // check if we will go "over" the Amount To Find.
+                if (amountFound + amountAtPeriod > amountToFind) {
                     cacheAmountAtPeriods[arrayIndex] = amountToFind - amountFound; // include only the partial amount
                     amountFound += cacheAmountAtPeriods[arrayIndex++];
                     break;

--- a/packages/contracts/test/src/token/ERC1155/RedeemOptimizerTest.t.sol
+++ b/packages/contracts/test/src/token/ERC1155/RedeemOptimizerTest.t.sol
@@ -7,6 +7,8 @@ import { IMultiTokenVault } from "@credbull/token/ERC1155/IMultiTokenVault.sol";
 
 import { MultiTokenVaultTest } from "@test/src/token/ERC1155/MultiTokenVaultTest.t.sol";
 
+import { console } from "forge-std/console.sol";
+
 contract RedeemOptimizerTest is MultiTokenVaultTest {
     function setUp() public override {
         super.setUp();
@@ -23,13 +25,15 @@ contract RedeemOptimizerTest is MultiTokenVaultTest {
         (uint256[] memory depositPeriods, uint256[] memory depositShares) = _testDeposits(alice, multiTokenVault); // make a few deposits
         uint256 totalDepositShares = depositShares[0] + depositShares[1] + depositShares[2];
 
-        // warp vault ahead redemPeriod
+        // warp vault ahead redeemPeriod
         uint256 redeemPeriod = deposit3TestParams.redeemPeriod;
         _warpToPeriod(multiTokenVault, redeemPeriod);
 
         // check full redeem
+        console.log("START REDEEM!");
         (uint256[] memory redeemDepositPeriods, uint256[] memory sharesAtPeriods) =
             redeemOptimizer.optimizeRedeemShares(multiTokenVault, alice, totalDepositShares, redeemPeriod);
+        console.log("END REDEEM!");
 
         assertEq(3, redeemDepositPeriods.length, "depositPeriods wrong length - full redeem");
         assertEq(3, sharesAtPeriods.length, "sharesAtPeriods wrong length - full redeem");
@@ -42,8 +46,10 @@ contract RedeemOptimizerTest is MultiTokenVaultTest {
         uint256[] memory expectedAssetsAtPeriods =
             multiTokenVault.convertToAssetsForDepositPeriods(depositShares, depositPeriods, redeemPeriod);
 
+        console.log("START WITHDRAW");
         (uint256[] memory withdrawDepositPeriods, uint256[] memory actualAssetsAtPeriods) =
             redeemOptimizer.optimizeWithdrawAssets(multiTokenVault, alice, totalDepositShares, redeemPeriod);
+        console.log("END WITHDRAW");
 
         assertEq(3, withdrawDepositPeriods.length, "depositPeriods wrong length - full redeem");
         assertEq(3, actualAssetsAtPeriods.length, "sharesAtPeriods wrong length - full redeem");

--- a/packages/contracts/test/src/token/ERC1155/RedeemOptimizerTest.t.sol
+++ b/packages/contracts/test/src/token/ERC1155/RedeemOptimizerTest.t.sol
@@ -51,8 +51,10 @@ contract RedeemOptimizerTest is MultiTokenVaultTest {
             redeemOptimizer.optimizeWithdrawAssets(multiTokenVault, alice, totalDepositShares, redeemPeriod);
         console.log("END WITHDRAW");
 
-        assertEq(3, withdrawDepositPeriods.length, "depositPeriods wrong length - full redeem");
-        assertEq(3, actualAssetsAtPeriods.length, "sharesAtPeriods wrong length - full redeem");
+        // assertEq(3, withdrawDepositPeriods.length, "depositPeriods wrong length - full redeem");
+        // assertEq(3, actualAssetsAtPeriods.length, "sharesAtPeriods wrong length - full redeem");
+        assertEq(2, withdrawDepositPeriods.length, "depositPeriods wrong length - full redeem");
+        assertEq(2, actualAssetsAtPeriods.length, "sharesAtPeriods wrong length - full redeem");
 
         assertEq(deposit1TestParams.depositPeriod, withdrawDepositPeriods[0], "optimizeWithdraw - wrong depositPeriod");
         assertEq(expectedAssetsAtPeriods[0], actualAssetsAtPeriods[0], "optimizeWithdraw - wrong assets");

--- a/packages/contracts/test/src/token/ERC1155/RedeemOptimizerTest.t.sol
+++ b/packages/contracts/test/src/token/ERC1155/RedeemOptimizerTest.t.sol
@@ -7,8 +7,6 @@ import { IMultiTokenVault } from "@credbull/token/ERC1155/IMultiTokenVault.sol";
 
 import { MultiTokenVaultTest } from "@test/src/token/ERC1155/MultiTokenVaultTest.t.sol";
 
-import { console } from "forge-std/console.sol";
-
 contract RedeemOptimizerTest is MultiTokenVaultTest {
     function setUp() public override {
         super.setUp();
@@ -30,36 +28,37 @@ contract RedeemOptimizerTest is MultiTokenVaultTest {
         _warpToPeriod(multiTokenVault, redeemPeriod);
 
         // check full redeem
-        console.log("START REDEEM!");
         (uint256[] memory redeemDepositPeriods, uint256[] memory sharesAtPeriods) =
             redeemOptimizer.optimizeRedeemShares(multiTokenVault, alice, totalDepositShares, redeemPeriod);
-        console.log("END REDEEM!");
 
         assertEq(3, redeemDepositPeriods.length, "depositPeriods wrong length - full redeem");
         assertEq(3, sharesAtPeriods.length, "sharesAtPeriods wrong length - full redeem");
 
-        assertEq(deposit1TestParams.depositPeriod, redeemDepositPeriods[0], "optimizeRedeem - wrong depositPeriod");
-        assertEq(depositShares[0], sharesAtPeriods[0], "optimizeRedeem - wrong shares");
+        assertEq(deposit1TestParams.depositPeriod, redeemDepositPeriods[0], "optimizeRedeem - wrong depositPeriod 0");
+        assertEq(depositShares[0], sharesAtPeriods[0], "optimizeRedeem - wrong shares 0");
 
-        // TODO - check the other depositPeriods
+        assertEq(deposit2TestParams.depositPeriod, redeemDepositPeriods[1], "optimizeRedeem - wrong depositPeriod 1");
+        assertEq(depositShares[1], sharesAtPeriods[1], "optimizeRedeem - wrong shares 1");
 
+        assertEq(deposit3TestParams.depositPeriod, redeemDepositPeriods[2], "optimizeRedeem - wrong depositPeriod 2");
+        assertEq(depositShares[2], sharesAtPeriods[2], "optimizeRedeem - wrong shares 2");
+
+        // Check full withdraw
         uint256[] memory expectedAssetsAtPeriods =
             multiTokenVault.convertToAssetsForDepositPeriods(depositShares, depositPeriods, redeemPeriod);
 
-        console.log("START WITHDRAW");
         (uint256[] memory withdrawDepositPeriods, uint256[] memory actualAssetsAtPeriods) =
             redeemOptimizer.optimizeWithdrawAssets(multiTokenVault, alice, totalDepositShares, redeemPeriod);
-        console.log("END WITHDRAW");
 
-        // assertEq(3, withdrawDepositPeriods.length, "depositPeriods wrong length - full redeem");
-        // assertEq(3, actualAssetsAtPeriods.length, "sharesAtPeriods wrong length - full redeem");
         assertEq(2, withdrawDepositPeriods.length, "depositPeriods wrong length - full redeem");
         assertEq(2, actualAssetsAtPeriods.length, "sharesAtPeriods wrong length - full redeem");
 
         assertEq(deposit1TestParams.depositPeriod, withdrawDepositPeriods[0], "optimizeWithdraw - wrong depositPeriod");
         assertEq(expectedAssetsAtPeriods[0], actualAssetsAtPeriods[0], "optimizeWithdraw - wrong assets");
 
-        // TODO - check the other withdrawPeriods
+        // This is a partial amount, as the 2 amounts satisfy the 'to find' criterion.
+        assertEq(deposit2TestParams.depositPeriod, withdrawDepositPeriods[1], "optimizeWithdraw - wrong depositPeriod");
+        assertEq(200 * SCALE, actualAssetsAtPeriods[1], "optimizeWithdraw - wrong partial assets");
     }
 
     function test__RedeemOptimizerTest__InsufficientSharesShouldRevert() public {


### PR DESCRIPTION
### Done
- [x] Optimise the loops in `RedeemOptimizerFIFO`. Currently, we loop twice for the whole period span, whereas we can loop once to do all the processing and then loop to trim the result arrays to the optimal size.
- [x] Fix issues in the `RedeemOptimizerTest` that were expecting the incorrect results.
    - Saves 250,000 gas, for the test in question. 