### PR TITLE
Re-work Yield Calculation to revert the previous 'inclusivity' change.

### DIFF
--- a/packages/contracts/src/yield/strategy/AbstractYieldStrategy.sol
+++ b/packages/contracts/src/yield/strategy/AbstractYieldStrategy.sol
@@ -10,15 +10,14 @@ import { IYieldStrategy } from "@credbull/yield/strategy/IYieldStrategy.sol";
 abstract contract AbstractYieldStrategy is IYieldStrategy {
     /**
      * @notice Calculate the number of periods in effect for Yield Calculation.
-     * @dev Encapsulates the algorithm for determining the number of periods to calculate yield with. The
-     *  number of periods is INCLUSIVE of the `from_` period. Thus the calculation is:
-     *      noOfPeriods = (`to_` - `from_`) + 1
+     * @dev Encapsulates the algorithm for determining the number of periods to calculate yield with. The calculation is:
+     *      noOfPeriods = (`to_` - `from_`)
      *
      * @param from_ The from period
      * @param to_ The to period
      * @return noOfPeriods_ The calculated effective number of periods.
      */
     function _noOfPeriods(uint256 from_, uint256 to_) internal pure virtual returns (uint256 noOfPeriods_) {
-        return (to_ - from_) + 1;
+        return to_ - from_;
     }
 }

--- a/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
+++ b/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
@@ -32,7 +32,7 @@ contract LiquidContinuousMultiTokenVaultTest is LiquidContinuousMultiTokenVaultT
     function test__LiquidContinuousVaultTest__BuyAndSell() public {
         LiquidContinuousMultiTokenVault liquidVault = _liquidVault; // _createLiquidContinueMultiTokenVault(_vaultParams);
 
-        TestParam memory testParams = TestParam({ principal: 2_000 * _scale, depositPeriod: 11, redeemPeriod: 70 });
+        TestParam memory testParams = TestParam({ principal: 2_000 * _scale, depositPeriod: 10, redeemPeriod: 70 });
 
         uint256 assetStartBalance = _asset.balanceOf(alice);
 
@@ -92,12 +92,12 @@ contract LiquidContinuousMultiTokenVaultTest is LiquidContinuousMultiTokenVaultT
         uint256 deposit = 50_000 * _scale;
 
         // verify returns
-        uint256 actualYield = _liquidVault.calcYield(deposit, 0, _liquidVault.TENOR() - 1);
+        uint256 actualYield = _liquidVault.calcYield(deposit, 0, _liquidVault.TENOR());
         assertEq(416_666666, actualYield, "interest not correct for $50k deposit after 30 days");
 
         // verify principal + returns
         uint256 actualShares = _liquidVault.convertToShares(deposit);
-        uint256 actualReturns = _liquidVault.convertToAssetsForDepositPeriod(actualShares, 0, _liquidVault.TENOR() - 1);
+        uint256 actualReturns = _liquidVault.convertToAssetsForDepositPeriod(actualShares, 0, _liquidVault.TENOR());
         assertEq(50_416_666666, actualReturns, "principal + interest not correct for $50k deposit after 30 days");
     }
 }

--- a/packages/contracts/test/src/yield/strategy/AbstractYieldStrategyTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/AbstractYieldStrategyTest.t.sol
@@ -16,7 +16,7 @@ contract AbstractYieldStrategyTest is AbstractYieldStrategy, Test {
         vm.assume(to_ < type(uint256).max);
 
         assertEq(
-            (to_ - from_) + 1,
+            to_ - from_,
             _noOfPeriods(from_, to_),
             string.concat(
                 "Incorrect No Of Periods: From: ",
@@ -31,13 +31,13 @@ contract AbstractYieldStrategyTest is AbstractYieldStrategy, Test {
         uint256, /* principal */
         uint256, /* fromTimePeriod */
         uint256 /* toTimePeriod */
-    ) external pure override returns (uint256 yield) {
+    ) public pure override returns (uint256 yield) {
         return 0;
     }
 
     /// @dev No impl stub.
     function calcPrice(address, /* contextContract */ uint256 /* numTimePeriodsElapsed */ )
-        external
+        public
         pure
         override
         returns (uint256 price)

--- a/packages/contracts/test/src/yield/strategy/SimpleInterestYieldStrategyTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/SimpleInterestYieldStrategyTest.t.sol
@@ -27,32 +27,32 @@ contract SimpleInterestYieldStrategyTest is Test {
 
         uint256 principal = 500 * SCALE;
 
-        // 500 * (6% / 360) * 2
+        // 500 * (6% / 360) * 1
         assertApproxEqAbs(
-            166_666,
+            83_333,
             yieldStrategy.calcYield(interestContractAddress, principal, 0, 1),
             TOLERANCE,
             "yield wrong at period 0 to 1"
         );
-        // 500 * (6% / 360) * 3
+        // 500 * (6% / 360) * 2
         assertApproxEqAbs(
-            250_000,
+            166_667,
             yieldStrategy.calcYield(interestContractAddress, principal, 1, 3),
             TOLERANCE,
             "yield wrong at period 1 to 3"
         );
-        // 500 * (6% / 360) * 31
+        // 500 * (6% / 360) * 30
         assertApproxEqAbs(
-            2_583_333,
+            2_500_000,
             yieldStrategy.calcYield(interestContractAddress, principal, 1, 31),
             TOLERANCE,
             "yield wrong at period 1 to 31"
         );
 
         address interest2Addr = address(_createInterestMetadata(apy * 2, frequency)); // double the interest rate
-        // 500 * (12% / 360) * 31
+        // 500 * (12% / 360) * 30
         assertApproxEqAbs(
-            5_166_667, // yield should also double
+            5_000_000, // yield should also double
             yieldStrategy.calcYield(interest2Addr, principal, 1, 31),
             TOLERANCE,
             "yield wrong at period 1 to 31 - double APY"

--- a/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/TripleRateYieldStrategyTest.t.sol
@@ -78,7 +78,7 @@ contract TripleRateYieldStrategyTest is Test {
         // $1,000 * ((5% / 365) * 21) = 2.876712
         assertApproxEqAbs(
             2_876_712,
-            yieldStrategy.calcYield(contextAddress, principal, 1, 21),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 22),
             TOLERANCE,
             "incorrect 21 day reduced rate yield"
         );
@@ -87,7 +87,7 @@ contract TripleRateYieldStrategyTest is Test {
         // $1,000 * ((5% / 365) * 29) = 3.972603
         assertApproxEqAbs(
             3_972_603,
-            yieldStrategy.calcYield(contextAddress, principal, 1, 29),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 30),
             TOLERANCE,
             "incorrect 29 day reduced rate yield"
         );
@@ -96,39 +96,39 @@ contract TripleRateYieldStrategyTest is Test {
         // $1,000 * ((10% / 365) * 30) = 8.219178
         assertApproxEqAbs(
             8_219_178,
-            yieldStrategy.calcYield(contextAddress, principal, 1, 30),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 31),
             TOLERANCE,
             "incorrect 30 day full rate yield"
         );
 
-        // 32 Days, no current tenor update:
-        // ($1,000 * ((10% / 365) * 30) + ($1,000 * ((5% / 365) * 2))) = 8.493151
+        // 32 Days, no current Period Rate update:
+        // $1,000 * ((10% / 365) * 30) + $1,000 * ((5% / 365) * 2) = 8.493151
         assertApproxEqAbs(
             8_493_151,
-            yieldStrategy.calcYield(contextAddress, principal, 1, 32),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 33),
             TOLERANCE,
             "incorrect 32 day combined rate yield"
         );
 
-        // Update current tenor at Day 31:
+        // Update current Period Rate at Day 31:
         context.setReducedRate(PERCENT_5_5_SCALED, 31);
 
         // 37 Days:
-        // ($1,000 * ((10% / 365) * 30) + ($1,000 * ((5.5% / 365) * 7))) = 9.273973
+        // $1,000 * ((10% / 365) * 30) + $1,000 * ((5.5% / 365) * 7) = 9.273973
         assertApproxEqAbs(
             9_273_973,
-            yieldStrategy.calcYield(contextAddress, principal, 1, 37),
+            yieldStrategy.calcYield(contextAddress, principal, 1, 38),
             TOLERANCE,
             "incorrect 37 day combined rate yield"
         );
 
-        // 22 Days, across Current Tenor Period:
-        // ($1,000 * ((5% / 365) * 11) + ($1,000 * ((5.5% / 365) * 11))) = 3.164384
+        // 22 Days, across Current Period Rate:
+        // $1,000 * ((5% / 365) * 10) + $1,000 * ((5.5% / 365) * 12) = 3.178082
         assertApproxEqAbs(
-            3_164_384,
-            yieldStrategy.calcYield(contextAddress, principal, 20, 41),
+            3_178_082,
+            yieldStrategy.calcYield(contextAddress, principal, 20, 42),
             TOLERANCE,
-            "incorrect 22 day across tenor periods rate yield"
+            "incorrect 22 day across current period rate yield"
         );
     }
 

--- a/packages/contracts/test/src/yield/strategy/YieldStrategyScenarioTest.t.sol
+++ b/packages/contracts/test/src/yield/strategy/YieldStrategyScenarioTest.t.sol
@@ -55,7 +55,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((5% / 365) * 15) =  2.054794
         assertEq(
             2_054_794,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 15),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 16),
             "reduced rate yield wrong at deposit + 15 days"
         );
     }
@@ -78,7 +78,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((5% / 365) * 20) =  2.739726
         assertEq(
             2_739_726,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 20),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 21),
             "reduced rate yield wrong at deposit + 20 days"
         );
     }
@@ -113,7 +113,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((10% / 365) * 30) = 8.219178
         assertEq(
             8_219_178,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 1, MATURITY_PERIOD),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, MATURITY_PERIOD + 1),
             "fully rate yield wrong at deposit + maturity days"
         );
     }
@@ -167,7 +167,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((10% / 365) * 30) + $1,000 * ((5.5% / 365) * 15) = 10.479452
         assertApproxEqAbs(
             10_479_452,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 45),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 46),
             TOLERANCE,
             "full + reduced rate yield wrong at deposit + 45 days"
         );
@@ -196,7 +196,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((10% / 365) * 30) + $1,000 * ((5.5% / 365) * 20) = 11.232876
         assertApproxEqAbs(
             11_232_876,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 50),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, 51),
             TOLERANCE,
             "full + reduced rate yield wrong at deposit + 50 days"
         );
@@ -241,7 +241,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((10% / 365) * 60) = 16.438356
         assertApproxEqAbs(
             16_438_356,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 1, (2 * MATURITY_PERIOD)),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, (2 * MATURITY_PERIOD) + 1),
             TOLERANCE,
             "full rate yield wrong at deposit + 2x maturity"
         );
@@ -272,7 +272,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((10% / 365) * 30) = 8.219718
         assertApproxEqAbs(
             8_219_178,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 1, MATURITY_PERIOD),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 1, MATURITY_PERIOD + 1),
             TOLERANCE,
             "full rate yield wrong at deposit + maturity"
         );
@@ -282,7 +282,7 @@ abstract contract YieldStrategyScenarioTest is Test {
         // $1,000 * ((5% / 365) * 16) = 2.191780
         assertApproxEqAbs(
             2_191_780,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 15, MATURITY_PERIOD),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 15, MATURITY_PERIOD + 1),
             TOLERANCE,
             "reduced rate yield wrong at deposit + 15 days"
         );
@@ -313,10 +313,10 @@ abstract contract YieldStrategyScenarioTest is Test {
         _setReducedRate(PERCENT_5_5_SCALED, 31);
 
         // User A
-        // Deposit on Day 1, Redeem Day 46 = 30 days at full rate and 16 days at reduced rate.
-        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 16) = 10.630137
+        // Deposit on Day 1, Redeem Day 46 = 30 days at full rate and 15 days at reduced rate.
+        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 15) = 10.479452
         assertApproxEqAbs(
-            10_630_137,
+            10_479_452,
             _yieldStrategy().calcYield(_contextAddress(), principal, 1, 46),
             TOLERANCE,
             "full + reduced rate yield wrong at deposit + maturity + 15"
@@ -324,9 +324,9 @@ abstract contract YieldStrategyScenarioTest is Test {
 
         // User B
         // Deposit on Day 15, Redeem Day 46 = 1 full rate and 2 days at reduced rate.
-        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 2) = 8.520548
+        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 1) = 8.369863
         assertApproxEqAbs(
-            8_520_548,
+            8_369_863,
             _yieldStrategy().calcYield(_contextAddress(), principal, 15, 46),
             TOLERANCE,
             "full rate yield wrong at deposit + maturity"
@@ -365,21 +365,21 @@ abstract contract YieldStrategyScenarioTest is Test {
         _setReducedRate(PERCENT_5_5_SCALED, 20);
 
         // User A
-        // Deposit on Day 1, Redeem Day 45 = 30 days at full rate and 15 days at 5.5% APY.
-        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 15) = 10.479452
+        // Deposit on Day 1, Redeem Day 45 = 30 days at full rate and 14 days at 5.5% APY.
+        // $1,000 * ((10% / 365) * 30) + 1,000 * ((5.5% / 365) * 14) = 10.328767
         assertApproxEqAbs(
-            10_479_452,
+            10_328_767,
             _yieldStrategy().calcYield(_contextAddress(), principal, 1, 45),
             TOLERANCE,
-            "full + reduced rate yield wrong at deposit + maturity + 15"
+            "full + reduced rate yield wrong at deposit + maturity + 14"
         );
 
         // User B
-        // Deposit on Day 17, Redeem Day 45 = 29 days at reduced rates.
+        // Deposit on Day 16, Redeem Day 45 = 29 days at reduced rates.
         // $1,000 * ((5% / 365) * 3) + $1,000 * ((5.5% / 365) * 26) = 4.328767
         assertApproxEqAbs(
             4_328_767,
-            _yieldStrategy().calcYield(_contextAddress(), principal, 17, 45),
+            _yieldStrategy().calcYield(_contextAddress(), principal, 16, 45),
             TOLERANCE,
             "reduced rate yield wrong at deposit + 29"
         );

--- a/packages/contracts/test/test/yield/context/MultipleRateContext.t.sol
+++ b/packages/contracts/test/test/yield/context/MultipleRateContext.t.sol
@@ -103,6 +103,7 @@ contract MultipleRateContext is Initializable, CalcInterestMetadata, IMultipleRa
                         cache[cacheIndex++] = tupleOf(i, rate);
                         break;
                     }
+                    if (i == 0) break; // Prevent underflow.
                 }
 
                 // If still none found, then the default rate applies.

--- a/packages/contracts/test/test/yield/strategy/MultipleRateYieldStrategy.t.sol
+++ b/packages/contracts/test/test/yield/strategy/MultipleRateYieldStrategy.t.sol
@@ -88,19 +88,16 @@ contract MultipleRateYieldStrategy is AbstractYieldStrategy {
         uint256 _periods;
         uint256 _rate;
 
-        // NOTE (JL,2024-10-03): The From Period is inclusive for Yield Calculation purposes. This manifests as some
-        //  '+ 1' operations when calculating period spans for yield calculation.
-
-        // A singluar Reduced Rate applies to the Period Range.
+        // A singular Reduced Rate applies to the Period Range.
         if (reducedRateScaled.length == 1) {
-            _periods = (toPeriod - firstReducedRatePeriod) + 1;
+            _periods = toPeriod - firstReducedRatePeriod;
             _rate = reducedRateScaled[0][1];
             reducedRateInterest += CalcSimpleInterest.calcInterest(principal, _rate, _periods, frequency, scale);
         }
         // Two Reduced Rates apply to the Period Range.
         else if (reducedRateScaled.length == 2) {
             // Apply each rate in series.
-            _periods = reducedRateScaled[1][0] - firstReducedRatePeriod;
+            _periods = ((reducedRateScaled[1][0] - 1) - (firstReducedRatePeriod + 1)) + 1;
             _rate = reducedRateScaled[0][1];
             reducedRateInterest += CalcSimpleInterest.calcInterest(principal, _rate, _periods, frequency, scale);
 
@@ -122,7 +119,7 @@ contract MultipleRateYieldStrategy is AbstractYieldStrategy {
                 // The last rate
                 else if (i == reducedRateScaled.length - 1) {
                     // Period is from this rates effectve period to the terminal `to` period.
-                    _periods = (toPeriod - reducedRateScaled[i][0]) + 1;
+                    _periods = toPeriod - reducedRateScaled[i][0];
                     // Rate is this rate.
                     _rate = reducedRateScaled[i][1];
                 }
@@ -158,9 +155,8 @@ contract MultipleRateYieldStrategy is AbstractYieldStrategy {
 
     /**
      * @notice Calculates the first 'reduced' Interest Rate Period after the `_from` period.
-     * @dev Encapsulates the algorithm that determines the first 'reduced' Interest Rate Period. Given that `from_`
-     *  period is INCLUSIVE, this means the calculation, IFF there are 'full' Interest Rate periods, is:
-     *      `from_` + `noOfFullRatePeriods_`
+     * @dev Encapsulates the algorithm that determines the first 'reduced' Interest Rate Period. The calculation,
+     *  IFF there are 'full' Interest Rate periods, is: `from_` + `noOfFullRatePeriods_`
      *  Otherwise, it is simply the `from_` value.
      *
      * @param noOfFullRatePeriods_  The number of Full Rate Periods


### PR DESCRIPTION
### Abstract 
The product spec is now clear on whether or not the Deposit Day is inclusive. It IS inclusive, but claims are only processed AFTER the relevant Maturity Period has elapsed, so the inclusivity is implicit. Nonetheless, for Yield Calculation, given a `from` and `to` period, the effective Period Span is `to` - `from`.

### To Do
- [x] Remove the existing inclusivity in Period Span calculations.
- [x] ONLY include the required changes.
- [x] Update all the tests to use adjusted period ranges and yields.