### PR TITLE
Update IComponentToken interface to follow Async Vault standard

### DIFF
--- a/packages/contracts/src/token/component/IComponentToken.sol
+++ b/packages/contracts/src/token/component/IComponentToken.sol
@@ -35,7 +35,7 @@ interface IComponentToken {
      * @param assets Amount of `asset` that has been deposited
      * @param shares Amount of shares that has been received in exchange
      */
-    // event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
+    event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
 
     /**
      * @notice Emitted when a redeem request is complete
@@ -45,8 +45,9 @@ interface IComponentToken {
      * @param assets Amount of `asset` that has been received in exchange
      * @param shares Amount of shares that has been redeemed
      */
-    // event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256
-    // shares);
+    event Withdraw(
+        address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256 shares
+    );
 
     // User Functions
 

--- a/packages/contracts/src/token/component/IComponentToken.sol
+++ b/packages/contracts/src/token/component/IComponentToken.sol
@@ -1,58 +1,140 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.23;
 
-/**
- * @title IComponentToken
- * @dev Interface for buying and selling tokens.
- *
- * Similar to ERC-4626 Tokenized Vault standard, here:
- * - currencyToken is the "asset" ERC20 token.  e.g. USDC or another stablecoin
- * - componentToken is the "share" ERC20 token.  i.e. the Vault token
- * //
- */
 interface IComponentToken {
-    // --------------------- Plume invoked ---------------------
+    // Events
 
     /**
-     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
-     * @param currencyTokenAmount Amount of CurrencyToken to send
-     * @return requestId Unique identifier for the buy request
+     * @notice Emitted when the owner of some assets submits a request to buy shares
+     * @param controller Controller of the request
+     * @param owner Source of the assets to deposit
+     * @param requestId Discriminator between non-fungible requests
+     * @param sender Address that submitted the request
+     * @param assets Amount of `asset` to deposit
      */
-    function requestBuy(uint256 currencyTokenAmount) external returns (uint256 requestId);
+    event DepositRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
+    );
 
     /**
-     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
-     * @param componentTokenAmount Amount of ComponentToken to send
-     * @return requestId Unique identifier for the sell request
+     * @notice Emitted when the owner of some shares submits a request to redeem assets
+     * @param controller Controller of the request
+     * @param owner Source of the shares to redeem
+     * @param requestId Discriminator between non-fungible requests
+     * @param sender Address that submitted the request
+     * @param shares Amount of shares to redeem
      */
-    function requestSell(uint256 componentTokenAmount) external returns (uint256 requestId);
-
-    // --------------------- Credbull invoked ---------------------
+    event RedeemRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares
+    );
 
     /**
-     * @notice Executes a request to buy ComponentToken with CurrencyToken
-     * @param requestor Address of the user or smart contract that requested the buy
-     * @param requestId Unique identifier for the request
-     * @param currencyTokenAmount Amount of CurrencyToken to send
-     * @param componentTokenAmount Amount of ComponentToken to receive
+     * @notice Emitted when a deposit request is complete
+     * @param sender Controller of the request
+     * @param owner Source of the assets to deposit
+     * @param assets Amount of `asset` that has been deposited
+     * @param shares Amount of shares that has been received in exchange
      */
-    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount)
-        external;
+    // event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);
 
     /**
-     * @notice Executes a request to sell ComponentToken for CurrencyToken
-     * @param requestor Address of the user or smart contract that requested the sell
-     * @param requestId Unique identifier for the request
-     * @param currencyTokenAmount Amount of CurrencyToken to receive
-     * @param componentTokenAmount Amount of ComponentToken to send
+     * @notice Emitted when a redeem request is complete
+     * @param sender Controller of the request
+     * @param receiver Address to receive the assets
+     * @param owner Source of the shares to redeem
+     * @param assets Amount of `asset` that has been received in exchange
+     * @param shares Amount of shares that has been redeemed
      */
-    function executeSell(
-        address requestor,
-        uint256 requestId,
-        uint256 currencyTokenAmount,
-        uint256 componentTokenAmount
-    ) external;
+    // event Withdraw(address indexed sender, address indexed receiver, address indexed owner, uint256 assets, uint256
+    // shares);
 
-    /// @notice Returns the version of the ComponentToken interface
-    function getVersion() external view returns (uint256 version);
+    // User Functions
+
+    /**
+     * @notice Transfer assets from the owner into the vault and submit a request to buy shares
+     * @param assets Amount of `asset` to deposit
+     * @param controller Controller of the request
+     * @param owner Source of the assets to deposit
+     * @return requestId Discriminator between non-fungible requests
+     */
+    function requestDeposit(uint256 assets, address controller, address owner) external returns (uint256 requestId);
+
+    /**
+     * @notice Fulfill a request to buy shares by minting shares to the receiver
+     * @param assets Amount of `asset` that was deposited by `requestDeposit`
+     * @param receiver Address to receive the shares
+     * @param controller Controller of the request
+     */
+    function deposit(uint256 assets, address receiver, address controller) external returns (uint256 shares);
+
+    /**
+     * @notice Transfer shares from the owner into the vault and submit a request to redeem assets
+     * @param shares Amount of shares to redeem
+     * @param controller Controller of the request
+     * @param owner Source of the shares to redeem
+     * @return requestId Discriminator between non-fungible requests
+     */
+    function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256 requestId);
+
+    /**
+     * @notice Fulfill a request to redeem assets by transferring assets to the receiver
+     * @param shares Amount of shares that was redeemed by `requestRedeem`
+     * @param receiver Address to receive the assets
+     * @param controller Controller of the request
+     */
+    function redeem(uint256 shares, address receiver, address controller) external returns (uint256 assets);
+
+    // Getter View Functions
+
+    /// @notice Address of the `asset` token
+    function asset() external view returns (address assetTokenAddress);
+
+    /// @notice Total amount of `asset` held in the vault
+    function totalAssets() external view returns (uint256 totalManagedAssets);
+
+    /**
+     * @notice Equivalent amount of shares for the given amount of assets
+     * @param assets Amount of `asset` to convert
+     * @return shares Amount of shares that would be received in exchange
+     */
+    function convertToShares(uint256 assets) external view returns (uint256 shares);
+
+    /**
+     * @notice Equivalent amount of assets for the given amount of shares
+     * @param shares Amount of shares to convert
+     * @return assets Amount of `asset` that would be received in exchange
+     */
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
+
+    /**
+     * @notice Total amount of assets sent to the vault as part of pending deposit requests
+     * @param requestId Discriminator between non-fungible requests
+     * @param controller Controller of the requests
+     * @return assets Amount of pending deposit assets for the given requestId and controller
+     */
+    function pendingDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets);
+
+    /**
+     * @notice Total amount of assets sitting in the vault as part of claimable deposit requests
+     * @param requestId Discriminator between non-fungible requests
+     * @param controller Controller of the requests
+     * @return assets Amount of claimable deposit assets for the given requestId and controller
+     */
+    function claimableDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets);
+
+    /**
+     * @notice Total amount of shares sent to the vault as part of pending redeem requests
+     * @param requestId Discriminator between non-fungible requests
+     * @param controller Controller of the requests
+     * @return shares Amount of pending redeem shares for the given requestId and controller
+     */
+    function pendingRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
+
+    /**
+     * @notice Total amount of assets sitting in the vault as part of claimable redeem requests
+     * @param requestId Discriminator between non-fungible requests
+     * @param controller Controller of the requests
+     * @return shares Amount of claimable redeem shares for the given requestId and controller
+     */
+    function claimableRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
 }

--- a/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
+++ b/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
@@ -249,8 +249,8 @@ contract LiquidContinuousMultiTokenVault is
     }
 
     /// @notice Total amount of `asset` held in the vault
-    function totalAssets() public view returns (uint256 totalManagedAssets) {
-        // need to convert all - heavy operation but possible
+    // TODO - need to convert all - heavy operation but possible
+    function totalAssets() public pure returns (uint256 totalManagedAssets) {
         return 0;
     }
 
@@ -289,7 +289,7 @@ contract LiquidContinuousMultiTokenVault is
      */
     function pendingDepositRequest(uint256, /* requestId */ address /* controller */ )
         public
-        view
+        pure
         returns (uint256 assets)
     {
         // fine - we don't use async buy
@@ -302,7 +302,7 @@ contract LiquidContinuousMultiTokenVault is
      */
     function claimableDepositRequest(uint256, /* requestId */ address /* controller */ )
         public
-        view
+        pure
         returns (uint256 assets)
     {
         // fine - we don't use async buy
@@ -329,37 +329,7 @@ contract LiquidContinuousMultiTokenVault is
         return (currentPeriod() == requestId) ? pendingRedeemRequest(requestId, controller) : 0;
     }
 
-    // ===================== Buyable/Sellable =====================
-
-    // TODO deprecated - remove this function and call requestDeposit
-    function requestBuy(uint256 currencyTokenAmount) public virtual returns (uint256 requestId_) {
-        return requestDeposit(currencyTokenAmount, address(0), _msgSender());
-    }
-
-    // TODO deprecated - remove this function and call requestRedeem
-    function requestSell(uint256 componentTokenAmount) public virtual returns (uint256 requestId) {
-        return requestRedeem(componentTokenAmount, address(0), _msgSender());
-    }
-
-    // TODO deprecated - remove this function and call redeem deposit
-    function executeBuy(
-        address requestor,
-        uint256, /* requestId */
-        uint256 currencyTokenAmount,
-        uint256 /* componentTokenAmount */
-    ) public {
-        deposit(currencyTokenAmount, requestor);
-    }
-
-    // TODO deprecated - remove this function and call redeem directly
-    function executeSell(
-        address requestor,
-        uint256, /* requestId */
-        uint256, /*currencyTokenAmount*/
-        uint256 componentTokenAmount
-    ) public {
-        redeem(componentTokenAmount, requestor, address(0));
-    }
+    // ===================== RedeemOptimizer =====================
 
     /// @dev set the IRedeemOptimizer
     function setRedeemOptimizer(IRedeemOptimizer redeemOptimizer) public onlyRole(OPERATOR_ROLE) {

--- a/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
+++ b/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
@@ -43,7 +43,7 @@ contract LiquidContinuousMultiTokenVaultTest is LiquidContinuousMultiTokenVaultT
 
         vm.startPrank(alice);
         _asset.approve(address(liquidVault), testParams.principal); // grant the vault allowance
-        liquidVault.requestBuy(testParams.principal);
+        liquidVault.requestDeposit(testParams.principal, address(0), alice);
         vm.stopPrank();
 
         assertEq(
@@ -62,7 +62,7 @@ contract LiquidContinuousMultiTokenVaultTest is LiquidContinuousMultiTokenVaultT
 
         // requestSell
         vm.prank(alice);
-        uint256 requestId = liquidVault.requestSell(sharesAmount);
+        liquidVault.requestRedeem(sharesAmount, address(0), alice);
         assertEq(
             sharesAmount,
             liquidVault.unlockRequestAmountByDepositPeriod(alice, testParams.depositPeriod),
@@ -77,7 +77,7 @@ contract LiquidContinuousMultiTokenVaultTest is LiquidContinuousMultiTokenVaultT
         _warpToPeriod(liquidVault, testParams.redeemPeriod);
 
         vm.prank(alice);
-        liquidVault.executeSell(alice, requestId, testParams.principal + expectedYield, sharesAmount);
+        liquidVault.redeem(testParams.principal, alice, address(0));
 
         assertEq(0, liquidVault.balanceOf(alice, testParams.depositPeriod), "user should have no shares remaining");
         assertEq(

--- a/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultUtilTest.t.sol
+++ b/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultUtilTest.t.sol
@@ -34,12 +34,12 @@ contract LiquidContinuousMultiTokenVaultUtilTest is LiquidContinuousMultiTokenVa
 
         TestParam memory testParams = TestParam({ principal: 2_000 * scale, depositPeriod: 11, redeemPeriod: 71 });
 
-        uint256 sharesAmount = testParams.principal; // 1 principal = 1 share
+        //uint256 sharesAmount = testParams.principal; // 1 principal = 1 share
         _warpToPeriod(vaultProxy, testParams.depositPeriod);
 
         vm.startPrank(alice);
         asset.approve(address(vaultProxy), testParams.principal); // grant the vault allowance
-        vaultProxy.executeBuy(alice, 0, testParams.principal, sharesAmount);
+        vaultProxy.deposit(testParams.principal, alice);
         vm.stopPrank();
 
         assertEq(

--- a/packages/contracts/test/test/script/DeployAndLoadLiquidMultiTokenVault.s.sol
+++ b/packages/contracts/test/test/script/DeployAndLoadLiquidMultiTokenVault.s.sol
@@ -91,13 +91,13 @@ contract DeployAndLoadLiquidMultiTokenVault is DeployLiquidMultiTokenVault {
             // --------------------- deposits ---------------------
             uint256 depositAmount = baseDepositAmount * vault.currentPeriod();
             asset.approve(address(vault), depositAmount);
-            vault.executeBuy(userWallet.addr(), 0, depositAmount, depositAmount);
+            vault.deposit(depositAmount, userWallet.addr());
 
             // --------------------- request sells ---------------------
 
             if (vault.currentPeriod() > vault.TENOR() - 5) {
                 // only request for the last few days - the rest won't help
-                vault.requestSell(totalUserDeposits / 10); // request to sell 10% of deposits so far
+                vault.requestRedeem(totalUserDeposits / 10, address(0), userWallet.addr()); // request to sell 10% of deposits so far
             }
 
             vm.stopBroadcast();


### PR DESCRIPTION
1. [ ]  requestDeposit: assert owner == address(nestStaking)
2. [ ] confirm w/ Plume requestRedeem(uint256 shares, address controller, address owner) external returns (uint256 requestId); - is this shares (as in principal/deposits) or actually the ERC-4626 share amount including returns?
3. [ ] for pending and claimable request view functions, we want this so the nest manager can see what the state of their assets / shares are in. i think you can just store this as a mapping and make it go up and down as people call requestDeposit / deposit / requestRedeem / redeem
4. [X] rename functions requestBuy->requestDeposit, requestSell->requestRedeem, executeBuy->deposit, executeSell->redeem
5. [X] requestDeposit: assert msg.sender == controller 
6. [X] asset() already implemented in MultiTokenVault
7. [X] convertToShares().   // ian - used for deposits, assumes depositPeriod == currentPeriod()
8. [X] totalAssets()
9. [X] convertToAssets(shares) // ian - WARNING convertToAssets(shares) is User-specific as no depositPeriod is specified.  for User-agnostic, use convertToAssetsForDepositPeriod(shares, depositPeriod)
10. [X] Emit events: DepositRequest, Deposit, RedeemRequest, Withdraw