### PR TITLE
Fix for: F-2024-6713 Users can earn yield while depositing funds for only a few seconds

### DIFF
--- a/packages/contracts/src/timelock/TimelockAsyncUnlock.sol
+++ b/packages/contracts/src/timelock/TimelockAsyncUnlock.sol
@@ -157,15 +157,15 @@ abstract contract TimelockAsyncUnlock is Initializable, ITimelockAsyncUnlock, Co
         virtual
         returns (uint256)
     {
-        return requestUnlock(owner, depositPeriods, amounts, minUnlockPeriod());
+        return _requestUnlock(owner, depositPeriods, amounts, minUnlockPeriod());
     }
 
-    function requestUnlock(
+    function _requestUnlock(
         address owner,
         uint256[] memory depositPeriods,
         uint256[] memory amounts,
         uint256 unlockPeriod
-    ) public virtual returns (uint256) {
+    ) internal virtual returns (uint256) {
         if (depositPeriods.length != amounts.length) {
             revert TimelockAsyncUnlock__InvalidArrayLength(depositPeriods.length, amounts.length);
         }

--- a/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
+++ b/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
@@ -236,7 +236,7 @@ contract LiquidContinuousMultiTokenVault is
             }
         }
 
-        uint256 requestId = requestUnlock(owner, depositPeriods, sharesAtPeriods, redeemPeriod);
+        uint256 requestId = _requestUnlock(owner, depositPeriods, sharesAtPeriods, redeemPeriod);
         emit RedeemRequest(controller, owner, requestId, _msgSender(), shares);
         return requestId;
     }


### PR DESCRIPTION
### To Do 
Fix the [Audit Finding](https://portal.hacken.io/App/Projects/Details/fd818fe5-a20c-478c-b036-cef56993c145/Finding/ae0bee4a-cf01-4796-b39c-3aba3eecf1e7)

This PR is **very** WIP.

### Done
- [x] Added the `internal` `TimelockAsyncUnlock._requestUnlock` to accept a `unlockPeriod` parameter.
- [x] Changed  `LiquidContinuousMultiTokenVault.requestRedeem` to increment the `minUnlockPeriod()` value if the `currentPeriod()` occurs in the optimised set of periods/amounts. If the current period is there, the User deposited earlier in the current period, so we extend the Unlock Period by 1.
- [x] Updated the proving test to show the changes.

### Outstanding
- [ ]  The Yield Calculation is done using the Redeem Period instead of the Request Redeem Period, which is the correct one.
- [ ] Time Granularity. The product spec refers to seconds, but the codebase is geared to Periods, which are currently 24 Hours.  
- [ ] Remove logging.
