### PR TITLE
Add LiquidStone totalAssets for a given token owner

### DIFF
--- a/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
+++ b/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
@@ -545,6 +545,6 @@ contract LiquidContinuousMultiTokenVault is
     }
 
     function getVersion() public pure returns (uint256 version) {
-        return 1;
+        return 2;
     }
 }

--- a/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
+++ b/packages/contracts/src/yield/LiquidContinuousMultiTokenVault.sol
@@ -280,6 +280,19 @@ contract LiquidContinuousMultiTokenVault is
         return totalAssets_;
     }
 
+    /// @notice Total amount of `asset` held in the vault by the `owner`
+    // @dev - this is a heavy operation as the period of the vault increases
+    function totalAssets(address owner) public view returns (uint256 totalManagedAssets) {
+        uint256 totalAssets_ = 0;
+        uint256 currentPeriod_ = currentPeriod();
+
+        for (uint256 depositPeriod = 0; depositPeriod <= currentPeriod_; ++depositPeriod) {
+            totalAssets_ += convertToAssetsForDepositPeriod(balanceOf(owner, depositPeriod), depositPeriod);
+        }
+
+        return totalAssets_;
+    }
+
     /**
      * @notice Equivalent amount of shares for the given amount of assets
      * @param assets Amount of `asset` to convert

--- a/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
+++ b/packages/contracts/test/src/yield/LiquidContinuousMultiTokenVaultTest.t.sol
@@ -353,6 +353,12 @@ contract LiquidContinuousMultiTokenVaultTest is LiquidContinuousMultiTokenVaultT
         );
 
         assertEq(assetsAtRequestRedeemPeriod, _liquidVault.totalAssets(), "totalAssets wrong at requestRedeem period");
+        assertEq(
+            assetsAtRequestRedeemPeriod,
+            _liquidVault.totalAssets(alice),
+            "totalAssets(user) wrong at requestRedeem period"
+        );
+        assertEq(0, _liquidVault.totalAssets(bob), "totalAssets(user) wrong at requestRedeem period");
 
         // -------------- redeem period --------------
         _warpToPeriod(_liquidVault, redeemPeriod);
@@ -365,6 +371,8 @@ contract LiquidContinuousMultiTokenVaultTest is LiquidContinuousMultiTokenVaultT
         assertEq(assetsAtRedeemPeriod, _liquidVault.convertToAssets(totalShares), "assets wrong at redeem period");
 
         assertEq(assetsAtRedeemPeriod, _liquidVault.totalAssets(), "totalAssets wrong at redeem period");
+        assertEq(assetsAtRedeemPeriod, _liquidVault.totalAssets(alice), "totalAssets(alice) wrong at redeem period");
+        assertEq(0, _liquidVault.totalAssets(bob), "totalAssets(bob) wrong at redeem period");
     }
 
     function test__LiquidContinuousMultiTokenVault__DepositCallerValidation() public {


### PR DESCRIPTION
Add function to calculate the totalAssets in `LiquidContinuousMultiTokenVault` for a given depositor address.
